### PR TITLE
UDesktop: don't use quotes when opening URLs on macOS + Linux & use a vararg for `runCommand`

### DIFF
--- a/src/main/kotlin/gg/essential/universal/UDesktop.kt
+++ b/src/main/kotlin/gg/essential/universal/UDesktop.kt
@@ -71,13 +71,14 @@ object UDesktop {
     private fun openSystemSpecific(file: String): Boolean {
         return when {
             isLinux -> when {
-                isXdg -> runCommand("xdg-open \"$file\"")
-                isKde -> runCommand("kde-open \"$file\"")
-                isGnome -> runCommand("gnome-open \"$file\"")
-                else -> runCommand("kde-open \"$file\"") || runCommand("gnome-open \"$file\"")
+                isXdg -> runCommand("xdg-open", file)
+                isKde -> runCommand("kde-open", file)
+                isGnome -> runCommand("gnome-open", file)
+                else -> runCommand("kde-open", file) || runCommand("gnome-open", file)
             }
-            isMac -> runCommand("open \"$file\"")
-            isWindows -> runCommand("explorer \"$file\"")
+            isMac -> runCommand("open", file)
+            // Windows breaks with spaces in a path if we don't have quotes around it
+            isWindows -> runCommand("explorer", "\"$file\"")
             else -> false
         }
     }
@@ -87,10 +88,10 @@ object UDesktop {
             if (!Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
                 if (isLinux) {
                     return when {
-                        isXdg -> runCommand("xdg-open $uri")
-                        isKde -> runCommand("kde-open $uri")
-                        isGnome -> runCommand("gnome-open $uri")
-                        else -> runCommand("kde-open $uri") || runCommand("gnome-open $uri")
+                        isXdg -> runCommand("xdg-open", "$uri")
+                        isKde -> runCommand("kde-open", "$uri")
+                        isGnome -> runCommand("gnome-open", "$uri")
+                        else -> runCommand("kde-open", "$uri") || runCommand("gnome-open", "$uri")
                     }
 
                 }
@@ -126,7 +127,7 @@ object UDesktop {
         }
     }
 
-    private fun runCommand(command: String): Boolean {
+    private fun runCommand(vararg command: String): Boolean {
         return try {
             Runtime.getRuntime().exec(command).let {
                 it != null && it.isAlive

--- a/src/main/kotlin/gg/essential/universal/UDesktop.kt
+++ b/src/main/kotlin/gg/essential/universal/UDesktop.kt
@@ -77,8 +77,7 @@ object UDesktop {
                 else -> runCommand("kde-open", file) || runCommand("gnome-open", file)
             }
             isMac -> runCommand("open", file)
-            // Windows breaks with spaces in a path if we don't have quotes around it
-            isWindows -> runCommand("explorer", "\"$file\"")
+            isWindows -> runCommand("explorer", file)
             else -> false
         }
     }


### PR DESCRIPTION
Using quotes in the `open` command causes it to not open the URL.
Removing the quotes around the URL allows any URL to open correctly.

I have recorded a [video](https://streamable.com/al0qfr) to demonstrate this. This has also been tested in my mod environment and works as expected now.

*This supersedes #14*