### PR TITLE
Add miscelaneous MC-independent methods

### DIFF
--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -1002,6 +1002,7 @@ public final class gg/essential/universal/utils/ReleasedDynamicTexture : net/min
 	public fun <init> (II)V
 	public fun <init> (Lnet/minecraft/client/texture/NativeImage;)V
 	public fun close ()V
+	public final fun getDynamicGlId ()I
 	public fun getGlId ()I
 	public final fun getHeight ()I
 	public final fun getUploaded ()Z
@@ -1018,6 +1019,7 @@ public final class gg/essential/universal/utils/ReleasedDynamicTexture : net/min
 	public fun <init> (Lnet/minecraft/client/renderer/texture/NativeImage;)V
 	@1.16.2-forge
 	public fun close ()V
+	public final fun getDynamicGlId ()I
 	public fun getGlTextureId ()I
 	public final fun getHeight ()I
 	public final fun getUploaded ()Z
@@ -1048,6 +1050,7 @@ public final class gg/essential/universal/utils/ReleasedDynamicTexture : net/min
 	public fun close ()V
 	@1.12.2-forge,1.8.9-forge
 	public fun <init> (Ljava/awt/image/BufferedImage;)V
+	public final fun getDynamicGlId ()I
 	@1.12.2-forge,1.8.9-forge
 	public fun getGlTextureId ()I
 	public final fun getHeight ()I

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -173,6 +173,7 @@ public class gg/essential/universal/UGraphics {
 	public static fun getActiveTexture ()I
 	public static fun getCharWidth (C)F
 	public static fun getEmptyTexture ()Lgg/essential/universal/utils/ReleasedDynamicTexture;
+	public static fun getFontHeight ()I
 	public static fun getFromTessellator ()Lgg/essential/universal/UGraphics;
 	public static fun getStringWidth (Ljava/lang/String;)I
 	@1.17.1-forge,1.18.1-forge

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -104,24 +104,27 @@ public class gg/essential/universal/UGraphics {
 	public fun asUVertexConsumer ()Lgg/essential/universal/vertex/UVertexConsumer;
 	@1.17.1-forge,1.18.1-forge
 	public fun begin (ILcom/mojang/blaze3d/vertex/VertexFormat;)Lgg/essential/universal/UGraphics;
+	public fun begin (ILgg/essential/universal/UGraphics$CommonVertexFormats;)Lgg/essential/universal/UGraphics;
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric
 	public fun begin (ILnet/minecraft/client/render/VertexFormat;)Lgg/essential/universal/UGraphics;
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric
 	public fun beginRenderLayer (Lnet/minecraft/client/render/RenderLayer;)Lgg/essential/universal/UGraphics;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric
-	public fun beginWithActiveShader (Lgg/essential/universal/UGraphics$DrawMode;Lnet/minecraft/client/render/VertexFormat;)Lgg/essential/universal/UGraphics;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric
-	public fun beginWithDefaultShader (Lgg/essential/universal/UGraphics$DrawMode;Lnet/minecraft/client/render/VertexFormat;)Lgg/essential/universal/UGraphics;
 	@1.12.2-forge,1.15.2-forge,1.16.2-forge,1.8.9-forge
 	public fun begin (ILnet/minecraft/client/renderer/vertex/VertexFormat;)Lgg/essential/universal/UGraphics;
 	@1.16.2-forge,1.17.1-forge,1.18.1-forge
 	public fun beginRenderLayer (Lnet/minecraft/client/renderer/RenderType;)Lgg/essential/universal/UGraphics;
 	@1.17.1-forge,1.18.1-forge
 	public fun beginWithActiveShader (Lgg/essential/universal/UGraphics$DrawMode;Lcom/mojang/blaze3d/vertex/VertexFormat;)Lgg/essential/universal/UGraphics;
+	public fun beginWithActiveShader (Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;)Lgg/essential/universal/UGraphics;
 	@1.17.1-forge,1.18.1-forge
 	public fun beginWithDefaultShader (Lgg/essential/universal/UGraphics$DrawMode;Lcom/mojang/blaze3d/vertex/VertexFormat;)Lgg/essential/universal/UGraphics;
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric
+	public fun beginWithActiveShader (Lgg/essential/universal/UGraphics$DrawMode;Lnet/minecraft/client/render/VertexFormat;)Lgg/essential/universal/UGraphics;
 	@1.12.2-forge,1.15.2-forge,1.16.2-forge,1.8.9-forge
 	public fun beginWithActiveShader (Lgg/essential/universal/UGraphics$DrawMode;Lnet/minecraft/client/renderer/vertex/VertexFormat;)Lgg/essential/universal/UGraphics;
+	public fun beginWithDefaultShader (Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;)Lgg/essential/universal/UGraphics;
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric
+	public fun beginWithDefaultShader (Lgg/essential/universal/UGraphics$DrawMode;Lnet/minecraft/client/render/VertexFormat;)Lgg/essential/universal/UGraphics;
 	@1.12.2-forge,1.15.2-forge,1.16.2-forge,1.8.9-forge
 	public fun beginWithDefaultShader (Lgg/essential/universal/UGraphics$DrawMode;Lnet/minecraft/client/renderer/vertex/VertexFormat;)Lgg/essential/universal/UGraphics;
 	public static fun bindTexture (I)V
@@ -225,6 +228,19 @@ public class gg/essential/universal/UGraphics {
 	@1.12.2-forge,1.15.2-forge,1.16.2-fabric,1.16.2-forge,1.8.9-forge
 	public static fun translate (FFF)V
 	public static fun tryBlendFuncSeparate (IIII)V
+}
+
+public final class gg/essential/universal/UGraphics$CommonVertexFormats : java/lang/Enum {
+	public static final field POSITION Lgg/essential/universal/UGraphics$CommonVertexFormats;
+	public static final field POSITION_COLOR Lgg/essential/universal/UGraphics$CommonVertexFormats;
+	public static final field POSITION_COLOR_TEXTURE_LIGHT Lgg/essential/universal/UGraphics$CommonVertexFormats;
+	public static final field POSITION_TEXTURE Lgg/essential/universal/UGraphics$CommonVertexFormats;
+	public static final field POSITION_TEXTURE_COLOR Lgg/essential/universal/UGraphics$CommonVertexFormats;
+	public static final field POSITION_TEXTURE_COLOR_LIGHT Lgg/essential/universal/UGraphics$CommonVertexFormats;
+	public static final field POSITION_TEXTURE_COLOR_NORMAL Lgg/essential/universal/UGraphics$CommonVertexFormats;
+	public static final field POSITION_TEXTURE_LIGHT_COLOR Lgg/essential/universal/UGraphics$CommonVertexFormats;
+	public static fun valueOf (Ljava/lang/String;)Lgg/essential/universal/UGraphics$CommonVertexFormats;
+	public static fun values ()[Lgg/essential/universal/UGraphics$CommonVertexFormats;
 }
 
 public final class gg/essential/universal/UGraphics$DrawMode : java/lang/Enum {

--- a/src/main/java/gg/essential/universal/UGraphics.java
+++ b/src/main/java/gg/essential/universal/UGraphics.java
@@ -15,6 +15,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.texture.SimpleTexture;
 import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.renderer.vertex.VertexFormatElement;
 import net.minecraft.util.ResourceLocation;
@@ -27,7 +28,6 @@ import static org.lwjgl.opengl.GL13.GL_TEXTURE0;
 //#if MC>=11700
 //$$ import net.minecraft.client.render.GameRenderer;
 //$$ import net.minecraft.client.render.Shader;
-//$$ import net.minecraft.client.render.VertexFormats;
 //$$ import java.util.HashMap;
 //$$ import java.util.Map;
 //$$ import java.util.function.Supplier;
@@ -717,6 +717,28 @@ public class UGraphics {
         //#endif
     }
 
+    public enum CommonVertexFormats {
+        POSITION(DefaultVertexFormats.POSITION),
+        POSITION_COLOR(DefaultVertexFormats.POSITION_COLOR),
+        POSITION_TEXTURE(DefaultVertexFormats.POSITION_TEX),
+        POSITION_TEXTURE_COLOR(DefaultVertexFormats.POSITION_TEX_COLOR),
+        POSITION_COLOR_TEXTURE_LIGHT(DefaultVertexFormats.BLOCK),
+        POSITION_TEXTURE_LIGHT_COLOR(DefaultVertexFormats.POSITION_TEX_LMAP_COLOR),
+        POSITION_TEXTURE_COLOR_LIGHT(DefaultVertexFormats.PARTICLE_POSITION_TEX_COLOR_LMAP),
+        POSITION_TEXTURE_COLOR_NORMAL(DefaultVertexFormats.POSITION_TEX_COLOR_NORMAL),
+        ;
+
+        private final VertexFormat mc;
+
+        CommonVertexFormats(VertexFormat mc) {
+            this.mc = mc;
+        }
+    }
+
+    public UGraphics beginWithActiveShader(DrawMode mode, CommonVertexFormats format) {
+        return beginWithActiveShader(mode, format.mc);
+    }
+
     public UGraphics beginWithActiveShader(DrawMode mode, VertexFormat format) {
         vertexFormat = format;
         instance.begin(mode.mcMode, format);
@@ -740,6 +762,10 @@ public class UGraphics {
     //$$ }
     //#endif
 
+    public UGraphics beginWithDefaultShader(DrawMode mode, CommonVertexFormats format) {
+        return beginWithDefaultShader(mode, format.mc);
+    }
+
     public UGraphics beginWithDefaultShader(DrawMode mode, VertexFormat format) {
         //#if MC>=11700
         //$$ Supplier<Shader> supplier = DEFAULT_SHADERS.get(format);
@@ -759,6 +785,11 @@ public class UGraphics {
     //$$     return this;
     //$$ }
     //#endif
+
+    @Deprecated // use `beginWithDefaultShader` or `beginWithActiveShader` or `beginRenderLayer` instead
+    public UGraphics begin(int glMode, CommonVertexFormats format) {
+        return begin(glMode, format.mc);
+    }
 
     @Deprecated // use `beginWithDefaultShader` or `beginWithActiveShader` or `beginRenderLayer` instead
     public UGraphics begin(int glMode, VertexFormat format) {

--- a/src/main/java/gg/essential/universal/UGraphics.java
+++ b/src/main/java/gg/essential/universal/UGraphics.java
@@ -362,6 +362,10 @@ public class UGraphics {
         return UMinecraft.getFontRenderer().getStringWidth(in);
     }
 
+    public static int getFontHeight() {
+        return UMinecraft.getFontRenderer().FONT_HEIGHT;
+    }
+
     @Deprecated // Pass UMatrixStack as first arg, required for 1.17+
     public static void drawString(String text, float x, float y, int color, boolean shadow) {
         drawString(UNIT_STACK, text, x, y, color, shadow);

--- a/src/main/kotlin/gg/essential/universal/utils/ReleasedDynamicTexture.kt
+++ b/src/main/kotlin/gg/essential/universal/utils/ReleasedDynamicTexture.kt
@@ -83,6 +83,9 @@ class ReleasedDynamicTexture private constructor(
 
     private fun allocGlId() = super.getGlTextureId()
 
+    val dynamicGlId: Int
+        get() = getGlTextureId()
+
     override fun getGlTextureId(): Int {
         uploadTexture()
         return super.getGlTextureId()

--- a/versions/1.15.2-1.12.2.txt
+++ b/versions/1.15.2-1.12.2.txt
@@ -21,6 +21,7 @@ com.mojang.blaze3d.systems.RenderSystem enableTexture() net.minecraft.client.ren
 com.mojang.blaze3d.systems.RenderSystem disableTexture() net.minecraft.client.renderer.GlStateManager disableTexture2D()
 net.minecraft.client.renderer.vertex.VertexFormat hasUV() hasUvOffset()
 net.minecraft.client.renderer.vertex.VertexFormatElement$Usage net.minecraft.client.renderer.vertex.VertexFormatElement$EnumUsage
+net.minecraft.client.renderer.vertex.DefaultVertexFormats POSITION_TEX_LIGHTMAP_COLOR POSITION_TEX_LMAP_COLOR
 net.minecraft.client.renderer.entity.PlayerRenderer net.minecraft.client.renderer.entity.RenderPlayer
 net.minecraft.client.world.ClientWorld net.minecraft.client.multiplayer.WorldClient
 net.minecraft.client.entity.player.ClientPlayerEntity net.minecraft.client.entity.EntityPlayerSP


### PR DESCRIPTION
When [creating the MC-independent UC jar]( https://github.com/EssentialGG/essential-gradle-toolkit#stripreferencestransform) used for compiling the version-independent parts of Elementa, any types from MC and all methods referencing these are omitted (so you can't accidentally use version-dependent things).
There are a few common methods used all over Elementa though, and none of these are really MC-specific, so this PR adds MC-independent variants for those.

The removals in the API file aren't actual removals, those entries just got reordered because the algorithm, which merges the api files from the different versions, isn't perfectly stable wrt to surrounding entries.