### PR TITLE
Add UImage

### DIFF
--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -295,6 +295,36 @@ public final class gg/essential/universal/UGuiButton {
 	public static final fun getY (Lnet/minecraft/client/gui/GuiButton;)I
 }
 
+public final class gg/essential/universal/UImage {
+	public static final field Companion Lgg/essential/universal/UImage$Companion;
+	@1.17.1-forge,1.18.1-forge
+	public fun <init> (Lcom/mojang/blaze3d/platform/NativeImage;)V
+	@1.16.2-forge
+	public fun <init> (Lnet/minecraft/client/renderer/texture/NativeImage;)V
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric
+	public fun <init> (Lnet/minecraft/client/texture/NativeImage;)V
+	@1.12.2-forge,1.15.2-forge,1.8.9-forge
+	public fun <init> (Ljava/awt/image/BufferedImage;)V
+	public final fun copyFrom (Lgg/essential/universal/UImage;)V
+	@1.17.1-forge,1.18.1-forge
+	public final fun getNative ()Lcom/mojang/blaze3d/platform/NativeImage;
+	@1.16.2-forge
+	public final fun getNative ()Lnet/minecraft/client/renderer/texture/NativeImage;
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric
+	public final fun getNative ()Lnet/minecraft/client/texture/NativeImage;
+	@1.12.2-forge,1.15.2-forge,1.8.9-forge
+	public final fun getNative ()Ljava/awt/image/BufferedImage;
+	public static final fun ofSize (II)Lgg/essential/universal/UImage;
+	public static final fun ofSize (IIZ)Lgg/essential/universal/UImage;
+	public final fun set (III)V
+}
+
+public final class gg/essential/universal/UImage$Companion {
+	public final fun ofSize (II)Lgg/essential/universal/UImage;
+	public final fun ofSize (IIZ)Lgg/essential/universal/UImage;
+	public static synthetic fun ofSize$default (Lgg/essential/universal/UImage$Companion;IIZILjava/lang/Object;)Lgg/essential/universal/UImage;
+}
+
 public final class gg/essential/universal/UKeyboard {
 	public static final field INSTANCE Lgg/essential/universal/UKeyboard;
 	public static final field KEY_0 I

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -305,18 +305,22 @@ public final class gg/essential/universal/UImage {
 	public fun <init> (Lnet/minecraft/client/texture/NativeImage;)V
 	@1.12.2-forge,1.15.2-forge,1.8.9-forge
 	public fun <init> (Ljava/awt/image/BufferedImage;)V
+	public final fun copy ()Lgg/essential/universal/UImage;
 	public final fun copyFrom (Lgg/essential/universal/UImage;)V
+	public final fun getHeight ()I
 	@1.17.1-forge,1.18.1-forge
-	public final fun getNative ()Lcom/mojang/blaze3d/platform/NativeImage;
+	public final fun getNativeImage ()Lcom/mojang/blaze3d/platform/NativeImage;
 	@1.16.2-forge
-	public final fun getNative ()Lnet/minecraft/client/renderer/texture/NativeImage;
+	public final fun getNativeImage ()Lnet/minecraft/client/renderer/texture/NativeImage;
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric
-	public final fun getNative ()Lnet/minecraft/client/texture/NativeImage;
+	public final fun getNativeImage ()Lnet/minecraft/client/texture/NativeImage;
 	@1.12.2-forge,1.15.2-forge,1.8.9-forge
-	public final fun getNative ()Ljava/awt/image/BufferedImage;
+	public final fun getNativeImage ()Ljava/awt/image/BufferedImage;
+	public final fun getPixelRGB (II)I
+	public final fun getWidth ()I
 	public static final fun ofSize (II)Lgg/essential/universal/UImage;
 	public static final fun ofSize (IIZ)Lgg/essential/universal/UImage;
-	public final fun set (III)V
+	public final fun setPixelRGB (III)V
 }
 
 public final class gg/essential/universal/UImage$Companion {
@@ -1443,3 +1447,4 @@ public final class gg/essential/universal/wrappers/message/UTextComponent$Compan
 	public final fun from (Ljava/lang/Object;)Lgg/essential/universal/wrappers/message/UTextComponent;
 	public final fun stripFormatting (Ljava/lang/String;)Ljava/lang/String;
 }
+

--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -316,11 +316,11 @@ public final class gg/essential/universal/UImage {
 	public final fun getNativeImage ()Lnet/minecraft/client/texture/NativeImage;
 	@1.12.2-forge,1.15.2-forge,1.8.9-forge
 	public final fun getNativeImage ()Ljava/awt/image/BufferedImage;
-	public final fun getPixelRGB (II)I
+	public final fun getPixelRGBA (II)I
 	public final fun getWidth ()I
 	public static final fun ofSize (II)Lgg/essential/universal/UImage;
 	public static final fun ofSize (IIZ)Lgg/essential/universal/UImage;
-	public final fun setPixelRGB (III)V
+	public final fun setPixelRGBA (III)V
 }
 
 public final class gg/essential/universal/UImage$Companion {

--- a/src/main/kotlin/gg/essential/universal/UImage.kt
+++ b/src/main/kotlin/gg/essential/universal/UImage.kt
@@ -1,0 +1,35 @@
+package gg.essential.universal
+
+import gg.essential.universal.utils.NImage
+
+class UImage(val native: NImage) {
+
+    fun copyFrom(other: UImage) {
+        val otherNative = other.native
+        //#if MC>=11600
+        //$$ native.copyImageData(otherNative);
+        //#else
+        native.graphics.drawImage(otherNative, 0, 0, otherNative.width, otherNative.height, null)
+        //#endif
+    }
+
+    fun set(x: Int, y: Int, color: Int) {
+        //#if MC>=11600
+        //$$ native.setPixelRGBA(x, y, color);
+        //#else
+        native.setRGB(x, y, color)
+        //#endif
+    }
+
+    companion object {
+        @JvmStatic
+        @JvmOverloads
+        fun ofSize(width: Int, height: Int, clear: Boolean = true): UImage {
+            //#if MC>=11600
+            //$$ return UImage(NImage(width, height, clear))
+            //#else
+            return UImage(NImage(width, height, NImage.TYPE_INT_ARGB))
+            //#endif
+        }
+    }
+}

--- a/src/main/kotlin/gg/essential/universal/UImage.kt
+++ b/src/main/kotlin/gg/essential/universal/UImage.kt
@@ -7,27 +7,47 @@ import java.awt.image.BufferedImage
 //#endif
 
 //#if MC>=11600
-//$$ class UImage(val native: NativeImage) {
+//$$ class UImage(val nativeImage: NativeImage) {
 //#else
-class UImage(val native: BufferedImage) {
+class UImage(val nativeImage: BufferedImage) {
 //#endif
 
     fun copyFrom(other: UImage) {
-        val otherNative = other.native
+        val otherNative = other.nativeImage
         //#if MC>=11600
-        //$$ native.copyImageData(otherNative);
+        //$$ nativeImage.copyImageData(otherNative)
         //#else
-        native.graphics.drawImage(otherNative, 0, 0, otherNative.width, otherNative.height, null)
+        nativeImage.graphics.drawImage(otherNative, 0, 0, otherNative.width, otherNative.height, null)
         //#endif
     }
 
-    fun set(x: Int, y: Int, color: Int) {
+    fun copy(): UImage {
         //#if MC>=11600
-        //$$ native.setPixelRGBA(x, y, color);
+        //$$ return UImage(NativeImage(getWidth(), getHeight(), nativeImage.format.hasAlpha()))
         //#else
-        native.setRGB(x, y, color)
+        return UImage(BufferedImage(getWidth(), getHeight(), nativeImage.type))
         //#endif
     }
+
+    fun getPixelRGB(x: Int, y: Int): Int {
+        //#if MC>=11600
+        //$$ return nativeImage.getPixelRGBA(x, y)
+        //#else
+        return nativeImage.getRGB(x, y)
+        //#endif
+    }
+
+    fun setPixelRGB(x: Int, y: Int, color: Int) {
+        //#if MC>=11600
+        //$$ nativeImage.setPixelRGBA(x, y, color)
+        //#else
+        nativeImage.setRGB(x, y, color)
+        //#endif
+    }
+
+    fun getWidth() = nativeImage.width
+
+    fun getHeight() = nativeImage.height
 
     companion object {
         @JvmStatic

--- a/src/main/kotlin/gg/essential/universal/UImage.kt
+++ b/src/main/kotlin/gg/essential/universal/UImage.kt
@@ -1,8 +1,16 @@
 package gg.essential.universal
 
-import gg.essential.universal.utils.NImage
+//#if MC<11600
+import java.awt.image.BufferedImage
+//#else
+//$$ import net.minecraft.client.renderer.texture.NativeImage
+//#endif
 
-class UImage(val native: NImage) {
+//#if MC>=11600
+//$$ class UImage(val native: NativeImage) {
+//#else
+class UImage(val native: BufferedImage) {
+//#endif
 
     fun copyFrom(other: UImage) {
         val otherNative = other.native
@@ -26,9 +34,9 @@ class UImage(val native: NImage) {
         @JvmOverloads
         fun ofSize(width: Int, height: Int, clear: Boolean = true): UImage {
             //#if MC>=11600
-            //$$ return UImage(NImage(width, height, clear))
+            //$$ return UImage(NativeImage(width, height, clear))
             //#else
-            return UImage(NImage(width, height, NImage.TYPE_INT_ARGB))
+            return UImage(BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB))
             //#endif
         }
     }

--- a/src/main/kotlin/gg/essential/universal/UImage.kt
+++ b/src/main/kotlin/gg/essential/universal/UImage.kt
@@ -29,19 +29,19 @@ class UImage(val nativeImage: BufferedImage) {
         //#endif
     }
 
-    fun getPixelRGB(x: Int, y: Int): Int {
+    fun getPixelRGBA(x: Int, y: Int): Int {
         //#if MC>=11600
         //$$ return nativeImage.getPixelRGBA(x, y)
         //#else
-        return nativeImage.getRGB(x, y)
+        return Integer.rotateLeft(nativeImage.getRGB(x, y), 8) // Convert ARGB to RGBA
         //#endif
     }
 
-    fun setPixelRGB(x: Int, y: Int, color: Int) {
+    fun setPixelRGBA(x: Int, y: Int, color: Int) {
         //#if MC>=11600
         //$$ nativeImage.setPixelRGBA(x, y, color)
         //#else
-        nativeImage.setRGB(x, y, color)
+        nativeImage.setRGB(x, y, Integer.rotateRight(color, 8)) // Convert RGBA to ARGB
         //#endif
     }
 

--- a/src/main/kotlin/gg/essential/universal/utils/typealises.kt
+++ b/src/main/kotlin/gg/essential/universal/utils/typealises.kt
@@ -34,3 +34,9 @@ typealias MCButton = net.minecraft.client.gui.GuiButton
 
 typealias MCStringTextComponent = net.minecraft.util.ChatComponentText
 typealias MCSChatPacket = net.minecraft.network.play.server.S02PacketChat
+
+//#if MC>=11600
+//$$ typealias NImage = net.minecraft.client.renderer.texture.NativeImage
+//#else
+typealias NImage = java.awt.image.BufferedImage
+//#endif

--- a/src/main/kotlin/gg/essential/universal/utils/typealises.kt
+++ b/src/main/kotlin/gg/essential/universal/utils/typealises.kt
@@ -34,9 +34,3 @@ typealias MCButton = net.minecraft.client.gui.GuiButton
 
 typealias MCStringTextComponent = net.minecraft.util.ChatComponentText
 typealias MCSChatPacket = net.minecraft.network.play.server.S02PacketChat
-
-//#if MC>=11600
-//$$ typealias NImage = net.minecraft.client.renderer.texture.NativeImage
-//#else
-typealias NImage = java.awt.image.BufferedImage
-//#endif


### PR DESCRIPTION
Rather than only in Essential, this would be more useful here.
Additions include getters for width and height, a setter for pixel RGB, and a copy method to create a new instance of a UImage.
The only other change is get was renamed to getPixelRGB for clarity.