### PR TITLE
UKeyboard: Ensure key index is within the valid range of the keyboard on LWJGL2

### DIFF
--- a/src/main/kotlin/gg/essential/universal/UKeyboard.kt
+++ b/src/main/kotlin/gg/essential/universal/UKeyboard.kt
@@ -291,7 +291,13 @@ object UKeyboard {
         //$$ val state = if (key < 20) GLFW.glfwGetMouseButton(window, key) else GLFW.glfwGetKey(window, key)
         //$$ return state == GLFW.GLFW_PRESS
         //#else
-        return if (key < 0) Mouse.isButtonDown(key + 100) else Keyboard.isKeyDown(key)
+        return if (key < 0) {
+            Mouse.isButtonDown(key + 100)
+        } else if (key < Keyboard.KEYBOARD_SIZE) {
+            Keyboard.isKeyDown(key)
+        } else {
+            false
+        }
         //#endif
     }
 


### PR DESCRIPTION
Otherwise, a call to isKeyDown that is out of range will throw an `ArrayIndexOutOfBoundsException`. Fixes EM-492.