### PR TITLE
UMatrixStack: Add version-independent model matrix accessor

### DIFF
--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -600,22 +600,23 @@ public final class gg/essential/universal/UMatrixStack$Entry {
 	public fun equals (Ljava/lang/Object;)Z
 	@1.17.1-forge,1.18.1-forge,1.19-forge
 	public final fun getModel ()Lcom/mojang/math/Matrix4f;
+	@1.16.2-forge
+	public final fun getModel ()Lnet/minecraft/util/math/vector/Matrix4f;
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric
+	public final fun getModel ()Lnet/minecraft/util/math/Matrix4f;
+	@1.15.2-forge
+	public final fun getModel ()Lnet/minecraft/client/renderer/Matrix4f;
+	@1.12.2-forge,1.8.9-forge
+	public final fun getModel ()Lorg/lwjgl/util/vector/Matrix4f;
+	public final fun getModelAsArray ()[F
 	@1.17.1-forge,1.18.1-forge,1.19-forge
 	public final fun getNormal ()Lcom/mojang/math/Matrix3f;
 	@1.16.2-forge
-	public final fun getModel ()Lnet/minecraft/util/math/vector/Matrix4f;
-	@1.16.2-forge
 	public final fun getNormal ()Lnet/minecraft/util/math/vector/Matrix3f;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric
-	public final fun getModel ()Lnet/minecraft/util/math/Matrix4f;
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric
 	public final fun getNormal ()Lnet/minecraft/util/math/Matrix3f;
 	@1.15.2-forge
-	public final fun getModel ()Lnet/minecraft/client/renderer/Matrix4f;
-	@1.15.2-forge
 	public final fun getNormal ()Lnet/minecraft/client/renderer/Matrix3f;
-	@1.12.2-forge,1.8.9-forge
-	public final fun getModel ()Lorg/lwjgl/util/vector/Matrix4f;
 	@1.12.2-forge,1.8.9-forge
 	public final fun getNormal ()Lorg/lwjgl/util/vector/Matrix3f;
 	public fun hashCode ()I

--- a/src/main/kotlin/gg/essential/universal/UMatrixStack.kt
+++ b/src/main/kotlin/gg/essential/universal/UMatrixStack.kt
@@ -241,6 +241,23 @@ class UMatrixStack private constructor(
             //#else
             Entry(Matrix4f.load(model, null), Matrix3f.load(normal, null))
             //#endif
+
+        /**
+         * Returns the model matrix in row-major order.
+         */
+        val modelAsArray: FloatArray
+            get() = with(model) {
+                //#if MC>=11400
+                //$$ FloatArray(16).also { write(FloatBuffer.wrap(it)) }
+                //#else
+                floatArrayOf(
+                    m00, m10, m20, m30,
+                    m01, m11, m21, m31,
+                    m02, m12, m22, m32,
+                    m03, m13, m23, m33,
+                )
+                //#endif
+            }
     }
 
     object Compat {


### PR DESCRIPTION
UniversalCraft generally makes for a pretty good abstraction of a significant
chunk of Minecraft, such that one can write code which is only compiled once but
works with all versions of Minecraft.
Such code however cannot access the model matrix of a UMatrixStack because its
type is `Matrix4f` which is a Minecraft type that changes across version.
This commit provides an accessor to retrieve the content of the matrix in a
version independent way (plain old FloatArray).