### PR TITLE
UMatrixStack: Fix `applyModelViewMatrix` being called too early

### DIFF
--- a/src/main/kotlin/gg/essential/universal/UMatrixStack.kt
+++ b/src/main/kotlin/gg/essential/universal/UMatrixStack.kt
@@ -169,11 +169,14 @@ class UMatrixStack private constructor(
     fun isEmpty(): Boolean = stack.size == 1
 
     fun applyToGlobalState() {
+        //#if MC>=11700
         //#if MC>=11800
         //$$ // FIXME preprocessor bug: should remap the intermediary name to yarn no problem
         //$$ RenderSystem.getModelViewStack().multiplyPositionMatrix(stack.last.model)
-        //#elseif MC>=11700
+        //#else
         //$$ RenderSystem.getModelViewStack().method_34425(stack.last.model)
+        //#endif
+        //$$ RenderSystem.applyModelViewMatrix()
         //#else
         stack.last.model.store(MATRIX_BUFFER)
         // Explicit cast to Buffer required so we do not use the JDK9+ override in FloatBuffer
@@ -213,7 +216,6 @@ class UMatrixStack private constructor(
         //#if MC>=11700
         //$$ val stack = RenderSystem.getModelViewStack()
         //$$ stack.push()
-        //$$ RenderSystem.applyModelViewMatrix()
         //#else
         UGraphics.GL.pushMatrix()
         //#endif


### PR DESCRIPTION
Modern MC has two global storage locations for matrices, the global model view stack (`RenderSystem.getModelViewStack`) and the currently active matrix (set via `RenderSystem.applyModelViewMatrix` which copies from the top of the aforementioned stack).
`UMatrixStack`'s `applyToGlobalState` is meant to apply in such a way that the user can immediately make use of the applied global state (i.e. it should apply to both global MC storage locations), however the current implementation calls `applyModelViewMatrix` too early, after pushing MC's global stack but before applying the top of the `UMatrixStack` to it.
This commit fixes that by moving the `applyModelViewMatrix` call to right after the multiplication which put our head on top of the vanilla stack.