### PR TITLE
UDesktop: use rundll32 instead of explorer.exe on Windows

### DIFF
--- a/src/main/kotlin/gg/essential/universal/UDesktop.kt
+++ b/src/main/kotlin/gg/essential/universal/UDesktop.kt
@@ -73,7 +73,7 @@ object UDesktop {
         return when {
             isLinux -> listOf("xdg-open", "kde-open", "gnome-open").any { runCommand(it, file, checkExitStatus = true) }
             isMac -> runCommand("open", file)
-            isWindows -> runCommand("explorer", file)
+            isWindows -> runCommand("rundll32", "url.dll,FileProtocolHandler", file)
             else -> false
         }
     }


### PR DESCRIPTION
This is what modern Minecraft uses, and seems to work better with a wide variety of URLs and files.

fixes #41