### PR TITLE
UGraphics: Fix incorrect default shader being used

### DIFF
--- a/src/main/java/gg/essential/universal/UGraphics.java
+++ b/src/main/java/gg/essential/universal/UGraphics.java
@@ -36,7 +36,7 @@ import static org.lwjgl.opengl.GL13.GL_TEXTURE0;
 //#if MC>=11700
 //$$ import net.minecraft.client.render.GameRenderer;
 //$$ import net.minecraft.client.render.Shader;
-//$$ import java.util.HashMap;
+//$$ import java.util.IdentityHashMap;
 //$$ import java.util.Map;
 //$$ import java.util.function.Supplier;
 //#endif
@@ -767,7 +767,9 @@ public class UGraphics {
     }
 
     //#if MC>=11700
-    //$$ private static final Map<VertexFormat, Supplier<Shader>> DEFAULT_SHADERS = new HashMap<>();
+    //$$ // Note: Needs to be an Identity hash map because VertexFormat's equals method is broken (compares via its
+    //$$ //       component Map but order very much matters for VertexFormat) as of 1.17
+    //$$ private static final Map<VertexFormat, Supplier<Shader>> DEFAULT_SHADERS = new IdentityHashMap<>();
     //$$ static {
     //$$     DEFAULT_SHADERS.put(VertexFormats.LINES, GameRenderer::getRenderTypeLinesShader);
     //$$     DEFAULT_SHADERS.put(VertexFormats.POSITION_TEXTURE_COLOR_LIGHT, GameRenderer::getParticleShader);


### PR DESCRIPTION
We store default shaders for each built-in vertex format in a `HashMap`. Turns out though that `VertexFormat`'s `equals` implementation is broken and returns true for two `VertexFormat`s that use the same elements but in a different order (such as PosTexColorLight vs PosTexLightColor). As a result if you tried to draw the former, it'd actually use the shader for the latter and misinterpret your light texture coordinates as the vertex color and vice versa, usually producing invalid or simply no visible output.