### PR TITLE
Build: Enable GitHub Actions based CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
           echo "org.gradle.workers.max=2" >> "$GRADLE_USER_HOME/gradle.properties"
 
       - name: Build
-        run: ./gradlew clean --stacktrace
+        run: ./gradlew build --stacktrace
 
       - name: Publish
         run: echo ./gradlew publish --stacktrace

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,9 @@ jobs:
           key: gradle-wrapper-${{ hashFiles('**/gradle-wrapper.properties') }}
       - uses: actions/cache@v3
         with:
-          path: ~/.gradle/caches
+          path: |
+            ~/.gradle/caches
+            **/loom-cache
           key: gradle-caches-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle.properties', 'gradle/*.versions.toml') }}
           restore-keys: |
             gradle-caches-${{ hashFiles('**/*.gradle*') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Publish
         run: echo ./gradlew publish --stacktrace
-        if: env.NEXUS_USER != null
+        if: env.ORG_GRADLE_PROJECT_nexus_user != null
         env:
-          NEXUS_USER: ${{ secrets.NEXUS_USER }}
-          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_nexus_user: ${{ secrets.NEXUS_USER }}
+          ORG_GRADLE_PROJECT_nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,13 +43,14 @@ jobs:
           # We also pin the amount of workers, so it doesn't break should GitHub increase the default available vCPUs.
           # We write these to GRADLE_USER_HOME to overrule the local "gradle.properties" of the project.
           mkdir -p "${GRADLE_USER_HOME:=~/.gradle}"
-          echo "org.gradle.jvmargs=-Xmx3G -Dkotlin.daemon.jvm.options=-Xmx512M" >> "$GRADLE_USER_HOME/gradle.properties"
+          echo "org.gradle.jvmargs=-Xmx2G -Dkotlin.daemon.jvm.options=-Xmx512M" >> "$GRADLE_USER_HOME/gradle.properties"
           echo "org.gradle.workers.max=2" >> "$GRADLE_USER_HOME/gradle.properties"
 
       - name: Build
-        # Split into two Gradle invocations because Loom's remapJar task (specifically the BuildSharedServiceManager)
-        # will not release any memory until all scheduled remapJar tasks have complete.
+        # Split into multiple Gradle invocations because Loom's remapJar task (specifically the
+        # BuildSharedServiceManager) will not release any memory until all scheduled remapJar tasks have complete.
         run: |
+          ./gradlew jar --stacktrace
           ./gradlew :{1.{8.9,12.2}-forge,1.{19,19.1}-fabric,1.{16.2,17.1,18.1}-{forge,fabric}}:build --stacktrace
           ./gradlew build --stacktrace
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      ORG_GRADLE_PROJECT_branch: ${{ github.head_ref || github.ref_name }}
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,14 +38,20 @@ jobs:
           echo "ORG_GRADLE_PROJECT_BUILD_ID=$(expr ${{ github.run_number }} + 290)" >> "$GITHUB_ENV"
           # GitHub runners are limited to 7GB of RAM, so we'll limit our Gradle Daemon process to about half of that
           # which is enough so long as parallel task execution is limited.
+          # We also need to limit the Kotlin Compiler Daemon to its default value (which it seems to be perfectly
+          # fine with) as otherwise it inherits the Gradle Daemon's jvmargs putting us above the runner limit.
           # We also pin the amount of workers, so it doesn't break should GitHub increase the default available vCPUs.
           # We write these to GRADLE_USER_HOME to overrule the local "gradle.properties" of the project.
           mkdir -p "${GRADLE_USER_HOME:=~/.gradle}"
-          echo "org.gradle.jvmargs=-Xmx4G" >> "$GRADLE_USER_HOME/gradle.properties"
+          echo "org.gradle.jvmargs=-Xmx3G -Dkotlin.daemon.jvm.options=-Xmx512M" >> "$GRADLE_USER_HOME/gradle.properties"
           echo "org.gradle.workers.max=2" >> "$GRADLE_USER_HOME/gradle.properties"
 
       - name: Build
-        run: ./gradlew build --stacktrace
+        # Split into two Gradle invocations because Loom's remapJar task (specifically the BuildSharedServiceManager)
+        # will not release any memory until all scheduled remapJar tasks have complete.
+        run: |
+          ./gradlew :{1.{8.9,12.2}-forge,1.{19,19.1}-fabric,1.{16.2,17.1,18.1}-{forge,fabric}}:build --stacktrace
+          ./gradlew build --stacktrace
 
       - name: Publish
         run: echo ./gradlew publish --stacktrace

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: Build & Publish
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: |
+            8
+            16
+            17
+          cache: gradle
+
+      - name: Setup environment
+        run: |
+          echo "ORG_GRADLE_PROJECT_BUILD_ID=$(expr ${{ github.run_number }} + 290)" >> "$GITHUB_ENV"
+          # GitHub runners are limited to 7GB of RAM, so we'll limit our Gradle Daemon process to about half of that
+          # which is enough so long as parallel task execution is limited.
+          # We also pin the amount of workers, so it doesn't break should GitHub increase the default available vCPUs.
+          # We write these to GRADLE_USER_HOME to overrule the local "gradle.properties" of the project.
+          mkdir -p "${GRADLE_USER_HOME:=~/.gradle}"
+          echo "org.gradle.jvmargs=-Xmx4G" >> "$GRADLE_USER_HOME/gradle.properties"
+          echo "org.gradle.workers.max=2" >> "$GRADLE_USER_HOME/gradle.properties"
+
+      - name: Build
+        run: ./gradlew build --stacktrace
+
+      - name: Publish
+        run: echo ./gradlew publish --stacktrace
+        if: env.NEXUS_USER != null
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
@@ -18,7 +19,19 @@ jobs:
             8
             16
             17
-          cache: gradle
+
+      # Can't use setup-java for this because https://github.com/actions/setup-java/issues/366
+      - uses: actions/cache@v3
+        with:
+          path: ~/.gradle/wrapper
+          key: gradle-wrapper-${{ hashFiles('**/gradle-wrapper.properties') }}
+      - uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: gradle-caches-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle.properties', 'gradle/*.versions.toml') }}
+          restore-keys: |
+            gradle-caches-${{ hashFiles('**/*.gradle*') }}
+            gradle-caches-
 
       - name: Setup environment
         run: |
@@ -32,7 +45,7 @@ jobs:
           echo "org.gradle.workers.max=2" >> "$GRADLE_USER_HOME/gradle.properties"
 
       - name: Build
-        run: ./gradlew build --stacktrace
+        run: ./gradlew clean --stacktrace
 
       - name: Publish
         run: echo ./gradlew publish --stacktrace

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
           ./gradlew build --stacktrace
 
       - name: Publish
-        run: echo ./gradlew publish --stacktrace
+        run: ./gradlew publish --stacktrace
         if: env.ORG_GRADLE_PROJECT_nexus_user != null
         env:
           ORG_GRADLE_PROJECT_nexus_user: ${{ secrets.NEXUS_USER }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,4 @@ org.gradle.parallel=true
 org.gradle.configureoncommand=true
 org.gradle.parallel.threads=4
 org.gradle.jvmargs=-Xmx8G
+# cache buster comment

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,3 @@ org.gradle.parallel=true
 org.gradle.configureoncommand=true
 org.gradle.parallel.threads=4
 org.gradle.jvmargs=-Xmx8G
-# cache buster comment

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -26,7 +26,6 @@ preprocess {
     val fabric11701 = createNode("1.17.1-fabric", 11701, "yarn")
     val fabric11602 = createNode("1.16.2-fabric", 11602, "yarn")
     val forge11602 = createNode("1.16.2-forge", 11602, "srg")
-    val forge11502 = createNode("1.15.2-forge", 11502, "srg")
     val forge11202 = createNode("1.12.2-forge", 11202, "srg")
     val forge10809 = createNode("1.8.9-forge", 10809, "srg")
 
@@ -46,7 +45,6 @@ preprocess {
     forge11701.link(fabric11701)
     fabric11701.link(fabric11602, file("versions/1.17.1-1.16.2.txt"))
     fabric11602.link(forge11602)
-    forge11602.link(forge11502, file("versions/1.16.2-1.15.2.txt"))
-    forge11502.link(forge11202, file("versions/1.15.2-1.12.2.txt"))
+    forge11602.link(forge11202, file("versions/1.16.2-1.12.2.txt"))
     forge11202.link(forge10809, file("versions/1.12.2-1.8.9.txt"))
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,6 @@ rootProject.buildFileName = "root.gradle.kts"
 listOf(
     "1.8.9-forge",
     "1.12.2-forge",
-    "1.15.2-forge",
     "1.16.2-forge",
     "1.16.2-fabric",
     "1.17.1-fabric",

--- a/versions/1.16.2-1.12.2.txt
+++ b/versions/1.16.2-1.12.2.txt
@@ -5,12 +5,12 @@ net.minecraft.util.SoundEvents net.minecraft.init.SoundEvents
 net.minecraft.client.renderer.texture.Texture net.minecraft.client.renderer.texture.AbstractTexture
 net.minecraft.resources.IResourceManager net.minecraft.client.resources.IResourceManager
 net.minecraft.client.renderer.texture.TextureUtil prepareImage() allocateTexture()
-net.minecraft.client.renderer.Matrix3f org.lwjgl.util.vector.Matrix3f
-net.minecraft.client.renderer.Matrix4f org.lwjgl.util.vector.Matrix4f
-net.minecraft.client.renderer.Matrix4f write() org.lwjgl.util.vector.Matrix4f store()
-net.minecraft.client.renderer.Quaternion org.lwjgl.util.vector.Quaternion
-net.minecraft.client.renderer.Vector3f org.lwjgl.util.vector.Vector3f
-net.minecraft.client.renderer.Vector4f org.lwjgl.util.vector.Vector4f
+net.minecraft.util.math.vector.Matrix3f org.lwjgl.util.vector.Matrix3f
+net.minecraft.util.math.vector.Matrix4f org.lwjgl.util.vector.Matrix4f
+net.minecraft.util.math.vector.Matrix4f write() org.lwjgl.util.vector.Matrix4f store()
+net.minecraft.util.math.vector.Quaternion org.lwjgl.util.vector.Quaternion
+net.minecraft.util.math.vector.Vector3f org.lwjgl.util.vector.Vector3f
+net.minecraft.util.math.vector.Vector4f org.lwjgl.util.vector.Vector4f
 net.minecraft.client.gui.screen.Screen net.minecraft.client.gui.GuiScreen
 net.minecraft.client.gui.widget.Widget net.minecraft.client.gui.GuiButton
 net.minecraft.client.renderer.entity.RenderPlayer net.minecraft.client.renderer.entity.PlayerRenderer
@@ -32,8 +32,3 @@ net.minecraft.client.GameSettings net.minecraft.client.settings.GameSettings
 net.minecraft.client.gui.NewChatGui net.minecraft.client.gui.GuiNewChat
 net.minecraft.client.gui.screen.MainMenuScreen net.minecraft.client.gui.GuiMainMenu
 net.minecraft.network.play.server.SChatPacket net.minecraft.network.play.server.SPacketChat
-
-
-
-
-

--- a/versions/1.16.2-1.15.2.txt
+++ b/versions/1.16.2-1.15.2.txt
@@ -1,4 +1,0 @@
-net.minecraft.util.math.vector.Matrix3f net.minecraft.client.renderer.Matrix3f
-net.minecraft.util.math.vector.Matrix4f net.minecraft.client.renderer.Matrix4f
-net.minecraft.util.math.vector.Quaternion net.minecraft.client.renderer.Quaternion
-net.minecraft.util.math.vector.Vector3f net.minecraft.client.renderer.Vector3f


### PR DESCRIPTION
Also removes 1.15 because of a bug in archloom ([1]).
Diff between 1.16.2-forge before and after the removal shows no significant
changes:
<details>

```diff
diff -r org/main/java/gg/essential/universal/UGraphics.java versions/1.16.2-forge/build/preprocessed/main/java/gg/essential/universal/UGraphics.java
55,58c55,58
< //$$ import net.minecraft.client.renderer.Matrix3f;
< //$$ import net.minecraft.client.renderer.Matrix4f;
< //$$ import net.minecraft.client.renderer.Vector3f;
< //$$ import net.minecraft.client.renderer.Vector4f;
---
> //$$ import org.lwjgl.util.vector.Matrix3f;
> //$$ import org.lwjgl.util.vector.Matrix4f;
> //$$ import org.lwjgl.util.vector.Vector3f;
> //$$ import org.lwjgl.util.vector.Vector4f;
diff -r org/main/kotlin/gg/essential/universal/vertex/VanillaVertexConsumer.kt versions/1.16.2-forge/build/preprocessed/main/kotlin/gg/essential/universal/vertex/VanillaVertexConsumer.kt
9,12c9,12
< //$$ import net.minecraft.client.renderer.Matrix3f
< //$$ import net.minecraft.client.renderer.Matrix4f
< //$$ import net.minecraft.client.renderer.Vector3f
< //$$ import net.minecraft.client.renderer.Vector4f
---
> //$$ import org.lwjgl.util.vector.Matrix3f
> //$$ import org.lwjgl.util.vector.Matrix4f
> //$$ import org.lwjgl.util.vector.Vector3f
> //$$ import org.lwjgl.util.vector.Vector4f
diff -r org/main/kotlin/gg/essential/universal/wrappers/message/UTextComponent.kt versions/1.16.2-forge/build/preprocessed/main/kotlin/gg/essential/universal/wrappers/message/UTextComponent.kt
182c182
<         //$$     is String -> StringTextComponent(hoverValue as String)
---
>         //$$     is String -> TextComponentString(hoverValue as String)
185c185
<         //$$     else -> StringTextComponent(hoverValue.toString())
---
>         //$$     else -> TextComponentString(hoverValue.toString())
```

</details>

[1]: https://github.com/architectury/architectury-loom/issues/151

To be squashed on merge.

Publish doesn't work yet due to secrets not being set up, but otherwise should be good to review.