### PR TITLE
Build: Fix GitHub Actions out-of-memory issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,21 +46,12 @@ jobs:
           # fine with) as otherwise it inherits the Gradle Daemon's jvmargs putting us above the runner limit.
           # We also pin the amount of workers, so it doesn't break should GitHub increase the default available vCPUs.
           # We write these to GRADLE_USER_HOME to overrule the local "gradle.properties" of the project.
-          mkdir -p "${GRADLE_USER_HOME:=~/.gradle}"
+          mkdir -p "${GRADLE_USER_HOME:=$HOME/.gradle}"
           echo "org.gradle.jvmargs=-Xmx2G -Dkotlin.daemon.jvm.options=-Xmx512M" >> "$GRADLE_USER_HOME/gradle.properties"
           echo "org.gradle.workers.max=2" >> "$GRADLE_USER_HOME/gradle.properties"
 
       - name: Build
-        # Split into multiple Gradle invocations because Loom's remapJar task (specifically the
-        # BuildSharedServiceManager) will not release any memory until all scheduled remapJar tasks have complete.
-        run: |
-          ./gradlew clean --stacktrace
-          ./gradlew :{1.{8.9,12.2}-forge,1.{19,19.1}-fabric,1.{16.2,17.1,18.1}-{forge,fabric}}:jar --stacktrace
-          ./gradlew :{1.20-fabric,1.{19.2,19.3,19.4,20.1}-{forge,fabric}}:jar --stacktrace
-          ./gradlew jar --stacktrace
-          ./gradlew :{1.{8.9,12.2}-forge,1.{19,19.1}-fabric,1.{16.2,17.1,18.1}-{forge,fabric}}:build --stacktrace
-          ./gradlew :{1.20-fabric,1.{19.2,19.3,19.4,20.1}-{forge,fabric}}:build --stacktrace
-          ./gradlew build --stacktrace
+        run: ./gradlew build --stacktrace
 
       - name: Publish
         run: ./gradlew publish --stacktrace

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
         maven("https://repo.essential.gg/repository/maven-public")
     }
     plugins {
-        val egtVersion = "0.2.1"
+        val egtVersion = "0.3.0"
         id("gg.essential.multi-version.root") version egtVersion
         id("gg.essential.multi-version.api-validation") version egtVersion
     }


### PR DESCRIPTION
There were at least two (potentially more that were fixed by Loom 1.2 -> 1.3 update) issues that are fixed in this commit:
1. `~` does not expand inside `"`, unlike regular variables. As such the maximum heap size wasn't actually applied and instead Gradle was free to consume all the memory in the VM, eventually killing the actions runner, resulting in fairly unhelpful failure messages.
2. A workaround for the BuildSharedServiceManager issue has been applied in Essential Loom 1.3.12. With that, it now easily builds in a single pass.