### PR TITLE
Misc: Fix build reference badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,49 +52,49 @@ modImplementation(include("gg.essential:universalcraft-$mcVersion-$mcPlatform:$b
           <td>1.18.1</td>
           <td>fabric</td>
           <td>
-            <img alt="1.18.1-fabric" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.18.1-fabric/maven-metadata.xml">
+            <img alt="1.18.1-fabric" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.18.1-fabric/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.18.1</td>
           <td>forge</td>
           <td>
-            <img alt="1.18.1-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.18.1-forge/maven-metadata.xml">
+            <img alt="1.18.1-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.18.1-forge/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.17.1</td>
           <td>fabric</td>
           <td>
-            <img alt="1.17.1-fabric" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.17.1-fabric/maven-metadata.xml">
+            <img alt="1.17.1-fabric" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.17.1-fabric/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.17.1</td>
           <td>forge</td>
           <td>
-            <img alt="1.17.1-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.17.1-forge/maven-metadata.xml">
+            <img alt="1.17.1-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.17.1-forge/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.16.2</td>
           <td>forge</td>
           <td>
-            <img alt="1.16.2-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.16.2-forge/maven-metadata.xml">
+            <img alt="1.16.2-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.16.2-forge/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.12.2</td>
           <td>forge</td>
           <td>
-            <img alt="1.12.2-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.12.2-forge/maven-metadata.xml">
+            <img alt="1.12.2-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.12.2-forge/maven-metadata.xml">
           </td>
         </tr>
         <tr>
           <td>1.8.9</td>
           <td>forge</td>
           <td>
-            <img alt="1.8.9-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'pull'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.8.9-forge/maven-metadata.xml">
+            <img alt="1.8.9-forge" src="https://img.shields.io/badge/dynamic/xml?color=A97BFF&label=%20&query=/metadata/versioning/versions/version[not(contains(text(),'%2B'))][last()]&url=https://repo.essential.gg/repository/maven-releases/gg/essential/universalcraft-1.8.9-forge/maven-metadata.xml">
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
[Rendered](https://github.com/EssentialGG/UniversalCraft/blob/b52d53454ddfae4676107a5313d123107194fe7c/README.md)

Our new GitHub Actions CI now uses the proper branch name (instead of `pull-#`) for pull request artifacts, so the current filter is insufficient. This commit changes it to instead filter by `+`.

[no ci]