### PR TITLE
Build: Bump to 1.20.2 Fabric (from -rc2)

### DIFF
--- a/versions/1.20.2-fabric/gradle.properties
+++ b/versions/1.20.2-fabric/gradle.properties
@@ -1,3 +1,0 @@
-essential.defaults.loom.minecraft=com.mojang:minecraft:1.20.2-rc2
-essential.defaults.loom.mappings=net.fabricmc:yarn:1.20.2-rc2+build.1:v2
-essential.defaults.loom.fabric-loader=net.fabricmc:fabric-loader:0.14.22


### PR DESCRIPTION
essential-gradle-toolkit has been updated to provide 1.20.2 defaults in a previous commit.