### PR TITLE
UScreen: Fix background being drawn twice on 1.20.2+

### DIFF
--- a/src/main/kotlin/gg/essential/universal/UScreen.kt
+++ b/src/main/kotlin/gg/essential/universal/UScreen.kt
@@ -42,6 +42,7 @@ abstract class UScreen(
     private var guiScaleToRestore = -1
     private var restoringGuiScale = false
     private val screenToRestore: GuiScreen? = if (restoreCurrentGuiOnClose) currentScreen else null
+    private var suppressBackground = false
 
     //#if MC>=12000
     //$$ private var drawContexts = mutableListOf<DrawContext>()
@@ -154,6 +155,7 @@ abstract class UScreen(
     //$$     lastBackgroundMouseX = mouseX
     //$$     lastBackgroundMouseY = mouseY
     //$$     lastBackgroundDelta = delta
+    //$$     if (suppressBackground) return
     //#else
     //$$ final override fun renderBackground(context: DrawContext) {
     //#endif
@@ -262,6 +264,7 @@ abstract class UScreen(
     }
 
     open fun onDrawScreen(matrixStack: UMatrixStack, mouseX: Int, mouseY: Int, partialTicks: Float) {
+        suppressBackground = true
         //#if MC>=12000
         //$$ withDrawContext(matrixStack) { drawContext ->
         //$$     super.render(drawContext, mouseX, mouseY, partialTicks)
@@ -277,6 +280,7 @@ abstract class UScreen(
             //#endif
         }
         //#endif
+        suppressBackground = false
     }
 
     @Deprecated(


### PR DESCRIPTION
The contract for UScreen has always been that the user needs to explicitly call `onDrawBackground` from their `onDrawScreen` override if they want their screen to have a background; that's how it used to work in Minecraft prior to 1.20.2.

As of 1.20.2, `Screen.render` (called by `onDrawScreen`) now also draws the background in addition to vanilla elements, as such the background is drawn twice; and if a custom screen wishes to not have any background, it's draw anyway.

This commit fixes that by suppressing the vanilla background method call when it happens within our `super.render` call. That way users retain control over the background, and in a way that's consistent across versions.

Linear: EM-2544