### PR TITLE
Add multiply support to <1.14

### DIFF
--- a/src/main/kotlin/gg/essential/universal/UMatrixStack.kt
+++ b/src/main/kotlin/gg/essential/universal/UMatrixStack.kt
@@ -160,11 +160,9 @@ class UMatrixStack private constructor(
         //#if MC>=11903
         //$$ model.rotate(quaternion)
         //$$ normal.rotate(quaternion)
-        //#elseif MC>=11400
-        //$$ model.mul(quaternion)
-        //$$ normal.mul(quaternion)
         //#else
-        TODO("lwjgl quaternion multiply") // there seems to be no existing methods to do this
+        model.mul(quaternion)
+        normal.mul(quaternion)
         //#endif
     }
 


### PR DESCRIPTION
After some digging, I've found that `mul` does exist in the older versions. Not sure as to why it was commented out here, please let me know if I'm mistaken here.