### PR TITLE
Fix library being incorrectly declared as a `LIBRARY`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,11 +24,3 @@ tasks.withType<KotlinCompile> {
         apiVersion = "1.6"
     }
 }
-
-tasks.jar {
-    manifest {
-        if (platform.isModLauncher) {
-            attributes(mapOf("FMLModType" to "GAMELIBRARY"))
-        }
-    }
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,8 @@ tasks.withType<KotlinCompile> {
 
 tasks.jar {
     manifest {
-        attributes(mapOf("FMLModType" to "LIBRARY"))
+        if (platform.isModLauncher) {
+            attributes(mapOf("FMLModType" to "GAMELIBRARY"))
+        }
     }
 }


### PR DESCRIPTION
Closes #70

This corrects the library being incorrectly labelled as a `LIBRARY` and thus breaking usage with Sinytra Connector.

~~`LIBRARY` does not have access to minecraft classes because it is in the plugin layer. `GAMELIBRARY` is in the game layer so it can access minecraft classes.~~

![266791887-3cf30738-50d4-40e9-84c7-c8567d53a455](https://github.com/EssentialGG/UniversalCraft/assets/47618543/03af078e-6a07-417a-b6cc-aeeb8d608693)
Source: [SpongePowered/Sponge#3898](https://github.com/SpongePowered/Sponge/pull/3898)