### PR TITLE
Misc: Add remaining methods used by Elementa and Vigilance

### DIFF
--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -102,6 +102,7 @@ public class gg/essential/universal/UGraphics {
 	@1.12.2-forge,1.16.2-forge
 	public fun <init> (Lnet/minecraft/client/renderer/BufferBuilder;)V
 	public static fun activeTexture (I)V
+	public static fun alphaFunc (IF)V
 	public static fun areShadersSupported ()Z
 	public fun asUVertexConsumer ()Lgg/essential/universal/vertex/UVertexConsumer;
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge
@@ -174,6 +175,7 @@ public class gg/essential/universal/UGraphics {
 	public static fun enableDepth ()V
 	public static fun enableLight (I)V
 	public static fun enableLighting ()V
+	public static fun enableStencil ()V
 	public static fun enableTexture2D ()V
 	public fun endVertex ()Lgg/essential/universal/UGraphics;
 	public static fun getActiveTexture ()I
@@ -202,6 +204,7 @@ public class gg/essential/universal/UGraphics {
 	public static fun glGetShaderi (II)I
 	public static fun glLinkProgram (I)V
 	public static fun glUseProgram (I)V
+	public static fun isCoreProfile ()Z
 	public static fun isOpenGl21Supported ()Z
 	public fun light (II)Lgg/essential/universal/UGraphics;
 	public static fun listFormattedStringToWidth (Ljava/lang/String;I)Ljava/util/List;
@@ -302,6 +305,11 @@ public final class gg/essential/universal/UGuiButton {
 	public static final fun getX (Lnet/minecraft/client/gui/GuiButton;)I
 	@1.12.2-forge,1.8.9-forge
 	public static final fun getY (Lnet/minecraft/client/gui/GuiButton;)I
+}
+
+public final class gg/essential/universal/UI18n {
+	public static final field INSTANCE Lgg/essential/universal/UI18n;
+	public final fun i18n (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
 }
 
 public final class gg/essential/universal/UImage {
@@ -645,16 +653,17 @@ public final class gg/essential/universal/UMinecraft {
 	public static final field isRunningOnMac Z
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge
 	public static final fun getChatGUI ()Lnet/minecraft/client/gui/components/ChatComponent;
-	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge
-	public static final fun getFontRenderer ()Lnet/minecraft/client/gui/Font;
 	@1.16.2-forge
 	public static final fun getChatGUI ()Lnet/minecraft/client/gui/NewChatGui;
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric
 	public static final fun getChatGUI ()Lnet/minecraft/client/gui/hud/ChatHud;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric
-	public static final fun getFontRenderer ()Lnet/minecraft/client/font/TextRenderer;
 	@1.12.2-forge,1.8.9-forge
 	public static final fun getChatGUI ()Lnet/minecraft/client/gui/GuiNewChat;
+	public static final fun getCurrentScreenObj ()Ljava/lang/Object;
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge
+	public static final fun getFontRenderer ()Lnet/minecraft/client/gui/Font;
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric
+	public static final fun getFontRenderer ()Lnet/minecraft/client/font/TextRenderer;
 	@1.12.2-forge,1.16.2-forge,1.8.9-forge
 	public static final fun getFontRenderer ()Lnet/minecraft/client/gui/FontRenderer;
 	public static final fun getGuiScale ()I
@@ -695,6 +704,8 @@ public final class gg/essential/universal/UMinecraft {
 	public static final fun getWorld ()Lnet/minecraft/client/world/ClientWorld;
 	@1.12.2-forge,1.8.9-forge
 	public static final fun getWorld ()Lnet/minecraft/client/multiplayer/WorldClient;
+	public static final fun isCallingFromMinecraftThread ()Z
+	public static final fun setCurrentScreenObj (Ljava/lang/Object;)V
 	public static final fun setGuiScale (I)V
 }
 

--- a/src/main/java/gg/essential/universal/UGraphics.java
+++ b/src/main/java/gg/essential/universal/UGraphics.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 
 import gg.essential.universal.utils.ReleasedDynamicTexture;
 import gg.essential.universal.vertex.UVertexConsumer;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.texture.SimpleTexture;
@@ -18,6 +19,7 @@ import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.renderer.vertex.VertexFormatElement;
+import net.minecraft.client.shader.Framebuffer;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
 
@@ -179,6 +181,24 @@ public class UGraphics {
     }
     //#endif
 
+    public static boolean isCoreProfile() {
+        //#if MC>=11700
+        //$$ return true;
+        //#else
+        return false;
+        //#endif
+    }
+
+    @Deprecated // only works on Forge 1.12.2 and below (relies on a Forge patch)
+    public static void enableStencil() {
+        //#if MC<11400
+        Framebuffer framebuffer = Minecraft.getMinecraft().getFramebuffer();
+        if (!framebuffer.isStencilEnabled()) {
+            framebuffer.enableStencil();
+        }
+        //#endif
+    }
+
     public static void cullFace(int mode) {
         //#if MC>=11502
         //$$ GL11.glCullFace(mode);
@@ -247,6 +267,12 @@ public class UGraphics {
         //#else
         GlStateManager.disableAlpha();
         //#endif
+        //#endif
+    }
+
+    public static void alphaFunc(int func, float ref) {
+        //#if MC<11700
+        GlStateManager.alphaFunc(func, ref);
         //#endif
     }
 

--- a/src/main/kotlin/gg/essential/universal/UI18n.kt
+++ b/src/main/kotlin/gg/essential/universal/UI18n.kt
@@ -1,0 +1,9 @@
+package gg.essential.universal
+
+import net.minecraft.client.resources.I18n
+
+object UI18n {
+    fun i18n(key: String, vararg arguments: Any?): String {
+        return I18n.format(key, *arguments)
+    }
+}

--- a/src/main/kotlin/gg/essential/universal/UMinecraft.kt
+++ b/src/main/kotlin/gg/essential/universal/UMinecraft.kt
@@ -4,6 +4,7 @@ import net.minecraft.client.Minecraft
 import net.minecraft.client.entity.EntityPlayerSP
 import net.minecraft.client.gui.FontRenderer
 import net.minecraft.client.gui.GuiNewChat
+import net.minecraft.client.gui.GuiScreen
 import net.minecraft.client.multiplayer.WorldClient
 import net.minecraft.client.network.NetHandlerPlayClient
 import net.minecraft.client.settings.GameSettings
@@ -79,4 +80,23 @@ object UMinecraft {
 
     @JvmStatic
     fun getSettings(): GameSettings = getMinecraft().gameSettings
+
+    @JvmStatic
+    var currentScreenObj: Any?
+        get() = getMinecraft().currentScreen
+        set(value) {
+            //#if MC<11200
+            @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
+            //#endif
+            getMinecraft().displayGuiScreen(value as GuiScreen?)
+        }
+
+    @JvmStatic
+    fun isCallingFromMinecraftThread(): Boolean {
+        //#if MC>=11400
+        //$$ return Minecraft.getInstance().isOnExecutionThread
+        //#else
+        return Minecraft.getMinecraft().isCallingFromMinecraftThread
+        //#endif
+    }
 }


### PR DESCRIPTION
Once these are part of UC, Elementa and Vigilance will no longer have any direct MC dependencies, allowing us to publish only a single version each, instead of having to publish one per MC-version/mod loader as we do right now.

(Not sure why the `getFontRenderer` api entries moved, but they were indeed improperly sorted before.)