### PR TITLE
UGraphics: Fix regression in configureTexture

### DIFF
--- a/src/main/java/gg/essential/universal/UGraphics.java
+++ b/src/main/java/gg/essential/universal/UGraphics.java
@@ -387,11 +387,19 @@ public class UGraphics {
 
     public static void configureTexture(int glTextureId, Runnable block) {
         int prevTextureBinding = GL11.glGetInteger(GL_TEXTURE_BINDING_2D);
-        bindTexture(glTextureId);
+        //#if STANDALONE
+        //$$ glBindTexture(GL_TEXTURE_2D, glTextureId);
+        //#else
+        GlStateManager.bindTexture(glTextureId);
+        //#endif
 
         block.run();
 
-        bindTexture(prevTextureBinding);
+        //#if STANDALONE
+        //$$ glBindTexture(GL_TEXTURE_2D, prevTextureBinding);
+        //#else
+        GlStateManager.bindTexture(prevTextureBinding);
+        //#endif
     }
 
     public static void configureTextureUnit(int index, Runnable block) {


### PR DESCRIPTION
The `GlStateManager.bindTexture` calls were erroneously changed to `UGraphics.bindTexture` in 13c00ee9, however that method on 1.17+ does not actually bind the texture on the OpenGL level anymore, it only sets MC's global field which is insufficient for `configureTexture`.