### PR TITLE
Standalone: Fix slf4j logging and add default log4j config

### DIFF
--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -37,10 +37,12 @@ dependencies {
     // Same as above but we do not want to expose them to our downstream so we can eventually remove them
     implementation("org.apache.logging.log4j:log4j-api:2.23.1")
     implementation("org.apache.logging.log4j:log4j-core:2.23.1")
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.23.1")
+    implementation("org.apache.logging.log4j:log4j-slf4j2-impl:2.23.1")
     implementation("com.google.code.gson:gson:2.11.0")
     implementation("commons-codec:commons-codec:1.17.1")
     implementation("org.apache.httpcomponents:httpclient:4.5.14")
+    // Pretty colors in Console logs
+    implementation("net.minecrell:terminalconsoleappender:1.3.0")
 }
 
 tasks.processResources {

--- a/standalone/example/src/main/kotlin/gg/essential/example/main.kt
+++ b/standalone/example/src/main/kotlin/gg/essential/example/main.kt
@@ -11,7 +11,10 @@ import gg.essential.universal.standalone.runUniversalCraft
 import gg.essential.universal.UResolution
 import gg.essential.universal.UScreen
 import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
 import java.awt.Color
+
+private val LOGGER = LoggerFactory.getLogger("Example")
 
 fun main() = runUniversalCraft("Example", 1000, 600) { window ->
     val extraFontsLoaded = mutableStateOf(false)
@@ -22,6 +25,8 @@ fun main() = runUniversalCraft("Example", 1000, 600) { window ->
 
     UMinecraft.guiScale = 2 * (UResolution.viewportWidth / UResolution.windowWidth)
     UScreen.displayScreen(LayoutDslScreen { exampleScreen(extraFontsLoaded) })
+
+    LOGGER.info("All ready!")
 
     window.renderScreenUntilClosed()
 }

--- a/standalone/src/main/resources/log4j2.xml
+++ b/standalone/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <TerminalConsole name="Console">
+            <PatternLayout pattern="%style{[%d{HH:mm:ss.SSS}]}{blue} %highlight{[%t/%level]}{FATAL=red, ERROR=red, WARN=yellow, INFO=green, DEBUG=green, TRACE=blue} %style{(%logger{1})}{cyan} %highlight{%msg%n}{FATAL=red, ERROR=red, WARN=normal, INFO=normal, DEBUG=normal, TRACE=normal}" disableAnsi="${tca:disableAnsi}"/>
+        </TerminalConsole>
+    </Appenders>
+    <Loggers>
+        <Root level="all">
+            <AppenderRef ref="Console" level="${sys:log4j2.level:-info}"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
We use version 2 of slf4j, so we need to include the log4j adapter which was built for version 2, not the one for version 1.

With that, logging works, but it's using log4j's ugly default format and only emits WARN or above.
To improve the out-of-the-box behavior for Standalone UC, we add a default log4j config file; applications which require further customization can override it via one of the many way which log4j provides.

![](https://i.johni0702.de/mfAZE.png)