### PR TITLE
UScreen: Fix background drawing on 1.21.2+

### DIFF
--- a/src/main/kotlin/gg/essential/universal/UScreen.kt
+++ b/src/main/kotlin/gg/essential/universal/UScreen.kt
@@ -56,6 +56,9 @@ abstract class UScreen(
     //$$     mc.positionMatrix.set(uc.model)
     //$$     mc.normalMatrix.set(uc.normal)
     //$$     block(context)
+        //#if MC>=12102
+        //$$ context.draw()
+        //#endif
     //$$     context.matrices.pop()
     //$$ }
     //#endif


### PR DESCRIPTION
As of 1.21.2 MC's DrawContext will now by default buffer all drawn quads and only flush when strictly necessary.
This however requires that everyone is in on the batching and has all their calls batched as well, otherwise buffered stuff will get rendered much later than it was supposed to. E.g. the vanilla background (much more obvious with the Programmer Art pack which brings back the dirt background) will be rendered on top of most of the Elementa gui.

![](https://i.johni0702.de/h9vkW.png)

Ideally we'd get in on the batching too, but that's quite the task, so for the time being this commit fixes the issue by explictly flushing after every time we pass the DrawContext to a vanilla method (i.e. any time something could have been buffered).

For additional context see [this conversation in the Essential Discord](https://discord.com/channels/864592657572560958/945076010641141770/1328349760280854618).

Note: This issue is masked when running with Essential because [Essential already happens calls `draw` from one of its mixins](https://github.com/EssentialGG/Essential-Mod/blob/212bff942d1609eaf28ef2d86cd9d96dbc1f12b0/src/main/kotlin/gg/essential/gui/overlay/OverlayManagerImpl.kt#L359-L369). It can be made apparent again by installing ImmediatelyFast which [uses a different VertexConsumerProvider for gui rendering](https://github.com/RaphiMC/ImmediatelyFast/blob/32f231f3445b7d8b4fa8b86e4ba438bde1e1363e/common/src/main/java/net/raphimc/immediatelyfast/injection/mixins/core/MixinGameRenderer.java) making Essential's draw call on the vanilla VertexConsumerProvider ineffective.