### PR TITLE
UGraphics: Add `clearColor` and `clearDepth`

### DIFF
--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -145,6 +145,8 @@ public class gg/essential/universal/UGraphics {
 	@1.12.2-forge,1.16.2-forge,1.8.9-forge
 	public static fun bindTexture (Lnet/minecraft/util/ResourceLocation;)V
 	public static fun blendEquation (I)V
+	public static fun clearColor (FFFF)V
+	public static fun clearDepth (D)V
 	public fun color (FFFF)Lgg/essential/universal/UGraphics;
 	public fun color (IIII)Lgg/essential/universal/UGraphics;
 	public fun color (Ljava/awt/Color;)Lgg/essential/universal/UGraphics;

--- a/src/main/java/gg/essential/universal/UGraphics.java
+++ b/src/main/java/gg/essential/universal/UGraphics.java
@@ -637,6 +637,22 @@ public class UGraphics {
         //#endif
     }
 
+    public static void clearColor(float r, float g, float b, float a) {
+        //#if MC>=12105
+        //$$ GL11.glClearColor(r, g, b, a);
+        //#else
+        GlStateManager.clearColor(r, g, b, a);
+        //#endif
+    }
+
+    public static void clearDepth(double depth) {
+        //#if MC>=12105
+        //$$ GL11.glClearDepth(depth);
+        //#else
+        GlStateManager.clearDepth(depth);
+        //#endif
+    }
+
     public static void glClear(int mode) {
         GL11.glClear(mode);
     }


### PR DESCRIPTION
For use from MC-independent code, and easier use across versions (specifically 1.21.5).

(this already includes the 1.21.5 case because it happens to match the case required for the `:standalone` UC version which uses `MC==99999` and so is served by `>=12105`)