### PR TITLE
UTextComponent: Deprecate

### DIFF
--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -734,7 +734,23 @@ public final class gg/essential/universal/UMouse$Scaled {
 public final class gg/essential/universal/UPacket {
 	public static final field INSTANCE Lgg/essential/universal/UPacket;
 	public static final fun sendActionBarMessage (Lgg/essential/universal/wrappers/message/UTextComponent;)V
+	@1.8.9-forge
+	public static final fun sendActionBarMessage (Lnet/minecraft/util/IChatComponent;)V
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge
+	public static final fun sendActionBarMessage (Lnet/minecraft/network/chat/Component;)V
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
+	public static final fun sendActionBarMessage (Lnet/minecraft/text/Text;)V
+	@1.12.2-forge,1.16.2-forge
+	public static final fun sendActionBarMessage (Lnet/minecraft/util/text/ITextComponent;)V
 	public static final fun sendChatMessage (Lgg/essential/universal/wrappers/message/UTextComponent;)V
+	@1.8.9-forge
+	public static final fun sendChatMessage (Lnet/minecraft/util/IChatComponent;)V
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge
+	public static final fun sendChatMessage (Lnet/minecraft/network/chat/Component;)V
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
+	public static final fun sendChatMessage (Lnet/minecraft/text/Text;)V
+	@1.12.2-forge,1.16.2-forge
+	public static final fun sendChatMessage (Lnet/minecraft/util/text/ITextComponent;)V
 }
 
 public final class gg/essential/universal/UResolution {
@@ -1181,6 +1197,25 @@ public final class gg/essential/universal/utils/ReleasedDynamicTexture : net/min
 	public final fun uploadTexture ()V
 }
 
+public final class gg/essential/universal/utils/TextUtilsKt {
+	@1.8.9-forge
+	public static final fun toFormattedString (Lnet/minecraft/util/IChatComponent;)Ljava/lang/String;
+	@1.8.9-forge
+	public static final fun toUnformattedString (Lnet/minecraft/util/IChatComponent;)Ljava/lang/String;
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge
+	public static final fun toFormattedString (Lnet/minecraft/network/chat/Component;)Ljava/lang/String;
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge
+	public static final fun toUnformattedString (Lnet/minecraft/network/chat/Component;)Ljava/lang/String;
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
+	public static final fun toFormattedString (Lnet/minecraft/text/Text;)Ljava/lang/String;
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
+	public static final fun toUnformattedString (Lnet/minecraft/text/Text;)Ljava/lang/String;
+	@1.12.2-forge,1.16.2-forge
+	public static final fun toFormattedString (Lnet/minecraft/util/text/ITextComponent;)Ljava/lang/String;
+	@1.12.2-forge,1.16.2-forge
+	public static final fun toUnformattedString (Lnet/minecraft/util/text/ITextComponent;)Ljava/lang/String;
+}
+
 public abstract interface class gg/essential/universal/vertex/UVertexConsumer {
 	public static final field Companion Lgg/essential/universal/vertex/UVertexConsumer$Companion;
 	public fun color (FFFF)Lgg/essential/universal/vertex/UVertexConsumer;
@@ -1242,6 +1277,14 @@ public final class gg/essential/universal/wrappers/UPlayer {
 	public static final fun getUUID ()Ljava/util/UUID;
 	public static final fun hasPlayer ()Z
 	public static final fun sendClientSideMessage (Lgg/essential/universal/wrappers/message/UTextComponent;)V
+	@1.8.9-forge
+	public static final fun sendClientSideMessage (Lnet/minecraft/util/IChatComponent;)V
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge
+	public static final fun sendClientSideMessage (Lnet/minecraft/network/chat/Component;)V
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
+	public static final fun sendClientSideMessage (Lnet/minecraft/text/Text;)V
+	@1.12.2-forge,1.16.2-forge
+	public static final fun sendClientSideMessage (Lnet/minecraft/util/text/ITextComponent;)V
 }
 
 public final class gg/essential/universal/wrappers/message/UMessage {

--- a/src/main/kotlin/gg/essential/universal/UChat.kt
+++ b/src/main/kotlin/gg/essential/universal/UChat.kt
@@ -2,8 +2,9 @@ package gg.essential.universal
 
 //#if !STANDALONE
 import gg.essential.universal.wrappers.UPlayer
-import gg.essential.universal.wrappers.message.UMessage
-import gg.essential.universal.wrappers.message.UTextComponent
+//#if MC>=12105
+//$$ import net.minecraft.text.Text
+//#endif
 //#endif
 import java.util.regex.Pattern
 
@@ -21,15 +22,19 @@ object UChat {
     fun chat(obj: Any) {
         //#if STANDALONE
         //$$ println(obj)
+        //#elseif MC>=12105
+        //$$ if (!UPlayer.hasPlayer()) return
+        //$$ UPlayer.sendClientSideMessage(obj as? Text ?: Text.literal(obj.toString()))
         //#else
-        if (obj is String || obj is UTextComponent) {
-            UMessage(obj).chat()
+        @Suppress("DEPRECATION")
+        if (obj is String || obj is gg.essential.universal.wrappers.message.UTextComponent) {
+            gg.essential.universal.wrappers.message.UMessage(obj).chat()
         } else {
-            val component = UTextComponent.from(obj)
+            val component = gg.essential.universal.wrappers.message.UTextComponent.from(obj)
             if (component != null) {
                 component.chat()
             } else {
-                UMessage(obj.toString()).chat()
+                gg.essential.universal.wrappers.message.UMessage(obj.toString()).chat()
             }
         }
         //#endif
@@ -46,15 +51,18 @@ object UChat {
     fun actionBar(obj: Any) {
         //#if STANDALONE
         //$$ throw UnsupportedOperationException("actionBar($obj)")
+        //#elseif MC>=12105
+        //$$ UPacket.sendActionBarMessage(obj as? Text ?: Text.literal(obj.toString()))
         //#else
-        if (obj is String || obj is UTextComponent) {
-            UMessage(obj).actionBar()
+        @Suppress("DEPRECATION")
+        if (obj is String || obj is gg.essential.universal.wrappers.message.UTextComponent) {
+            gg.essential.universal.wrappers.message.UMessage(obj).actionBar()
         } else {
-            val component = UTextComponent.from(obj)
+            val component = gg.essential.universal.wrappers.message.UTextComponent.from(obj)
             if (component != null) {
                 component.actionBar()
             } else {
-                UMessage(obj.toString()).actionBar()
+                gg.essential.universal.wrappers.message.UMessage(obj.toString()).actionBar()
             }
         }
         //#endif

--- a/src/main/kotlin/gg/essential/universal/UKeyboard.kt
+++ b/src/main/kotlin/gg/essential/universal/UKeyboard.kt
@@ -9,7 +9,7 @@ package gg.essential.universal
 import net.minecraft.client.settings.KeyBinding
 
 //#if MC>=11600
-//$$ import gg.essential.universal.wrappers.message.UTextComponent
+//$$ import gg.essential.universal.utils.toUnformattedString
 //#endif
 
 //#if MC>=11502
@@ -342,7 +342,7 @@ object UKeyboard {
     fun getKeyName(keyBinding: KeyBinding): String? {
         //#if MC>=11400
         //#if MC>=11600
-        //$$ return UTextComponent(keyBinding.func_238171_j_()).unformattedText.let {
+        //$$ return keyBinding.func_238171_j_().toUnformattedString().let {
         //#else
         //$$ return keyBinding.localizedName?.let {
         //#endif

--- a/src/main/kotlin/gg/essential/universal/UPacket.kt
+++ b/src/main/kotlin/gg/essential/universal/UPacket.kt
@@ -1,7 +1,7 @@
 package gg.essential.universal
 
-import gg.essential.universal.wrappers.message.UTextComponent
 import net.minecraft.network.play.server.S02PacketChat
+import net.minecraft.util.IChatComponent
 
 //#if MC>=11602
 //$$ import gg.essential.universal.wrappers.UPlayer
@@ -35,8 +35,13 @@ private object ChatType {
 //#endif
 
 object UPacket {
+    //#if MC<12105
+    @Suppress("DEPRECATION")
     @JvmStatic
-    fun sendChatMessage(message: UTextComponent) {
+    fun sendChatMessage(message: gg.essential.universal.wrappers.message.UTextComponent) = sendChatMessage(message as IChatComponent)
+    //#endif
+    @JvmStatic
+    fun sendChatMessage(message: IChatComponent) {
         UMinecraft.getNetHandler()!!.handleChat(S02PacketChat(
             message,
             //#if MC>=11901
@@ -49,9 +54,14 @@ object UPacket {
             //#endif
         ))
     }
-    
+
+    //#if MC<12105
+    @Suppress("DEPRECATION")
     @JvmStatic
-    fun sendActionBarMessage(message: UTextComponent) {
+    fun sendActionBarMessage(message: gg.essential.universal.wrappers.message.UTextComponent) = sendActionBarMessage(message as IChatComponent)
+    //#endif
+    @JvmStatic
+    fun sendActionBarMessage(message: IChatComponent) {
         UMinecraft.getNetHandler()!!.handleChat(S02PacketChat(
             message,
             //#if MC>=11901

--- a/src/main/kotlin/gg/essential/universal/utils/textUtils.kt
+++ b/src/main/kotlin/gg/essential/universal/utils/textUtils.kt
@@ -1,0 +1,72 @@
+package gg.essential.universal.utils
+
+import net.minecraft.util.IChatComponent
+
+//#if MC>=11600
+//$$ import net.minecraft.util.ICharacterConsumer
+//$$ import net.minecraft.util.text.Color
+//$$ import net.minecraft.util.text.Style
+//$$ import net.minecraft.util.text.TextFormatting
+//#endif
+
+//#if MC>=11602
+//$$ private class TextBuilder(private val isFormatted: Boolean) : ICharacterConsumer {
+//$$     private val builder = StringBuilder()
+//$$     private var cachedStyle: Style? = null
+//$$
+//$$     override fun accept(index: Int, style: Style, codePoint: Int): Boolean  {
+//$$         if (isFormatted && style != cachedStyle) {
+//$$             cachedStyle = style
+//$$             builder.append(formatString(style))
+//$$         }
+//$$
+//$$         builder.append(codePoint.toChar())
+//$$         return true
+//$$     }
+//$$
+//$$     fun getString() = builder.toString()
+//$$
+//$$     private fun formatString(style: Style): String {
+//$$         val builder = StringBuilder("§r")
+//$$
+//$$         when {
+//$$             style.bold -> builder.append("§l")
+//$$             style.italic -> builder.append("§o")
+//$$             style.underlined -> builder.append("§n")
+//$$             style.strikethrough -> builder.append("§m")
+//$$             style.obfuscated -> builder.append("§k")
+//$$         }
+//$$
+//$$         style.color?.let(colorToFormatChar::get)?.let {
+//$$             builder.append(it)
+//$$         }
+//$$         return builder.toString()
+//$$     }
+//$$
+//$$     companion object {
+//$$         private val colorToFormatChar = TextFormatting.values().mapNotNull { format ->
+//$$             Color.fromTextFormatting(format)?.let { it to format }
+//$$         }.toMap()
+//$$     }
+//$$ }
+//#endif
+
+fun IChatComponent.toUnformattedString(): String {
+    //#if MC>=11600
+    //$$ val builder = TextBuilder(false)
+    //$$ func_241878_f().accept(builder)
+    //$$ return builder.getString()
+    //#else
+    return unformattedText
+    //#endif
+}
+
+fun IChatComponent.toFormattedString(): String {
+    //#if MC>=11600
+    //$$ val builder = TextBuilder(true)
+    //$$ func_241878_f().accept(builder)
+    //$$ return builder.getString()
+    //#else
+    return formattedText
+    //#endif
+}

--- a/src/main/kotlin/gg/essential/universal/wrappers/UPlayer.kt
+++ b/src/main/kotlin/gg/essential/universal/wrappers/UPlayer.kt
@@ -1,8 +1,8 @@
 package gg.essential.universal.wrappers
 
 import gg.essential.universal.UMinecraft
-import gg.essential.universal.wrappers.message.UTextComponent
 import net.minecraft.client.entity.EntityPlayerSP
+import net.minecraft.util.IChatComponent
 import java.util.*
 
 object UPlayer {
@@ -14,8 +14,14 @@ object UPlayer {
     @JvmStatic
     fun hasPlayer() = getPlayer() != null
 
+    //#if MC<12105
+    @Suppress("DEPRECATION")
     @JvmStatic
-    fun sendClientSideMessage(message: UTextComponent) {
+    fun sendClientSideMessage(message: gg.essential.universal.wrappers.message.UTextComponent) = sendClientSideMessage(message as IChatComponent)
+    //#endif
+
+    @JvmStatic
+    fun sendClientSideMessage(message: IChatComponent) {
         //#if MC>=12102
         //$$ getPlayer()!!.sendMessage(message, false)
         //#elseif MC>=11900

--- a/src/main/kotlin/gg/essential/universal/wrappers/message/UMessage.kt
+++ b/src/main/kotlin/gg/essential/universal/wrappers/message/UMessage.kt
@@ -1,3 +1,5 @@
+//#if MC<12105
+@file:Suppress("DEPRECATION")
 package gg.essential.universal.wrappers.message
 
 import gg.essential.universal.UMinecraft
@@ -13,6 +15,7 @@ import java.util.concurrent.ThreadLocalRandom
 //$$ import net.minecraft.util.text.IFormattableTextComponent
 //#endif
 
+@Deprecated("No longer exists as of 1.21.5, unmaintained even on versions before that. Use UChat instead.")
 class UMessage {
     private lateinit var _chatMessage: UTextComponent
     val messageParts: MutableList<UTextComponent> = mutableListOf()
@@ -146,3 +149,4 @@ internal fun printChatMessageWithOptionalDeletion(textComponent: UTextComponent,
     // as `V`, otherwise it'll infer `Ljava/lang/Object;` which does not match our target method.
     printChatMessageWithOptionalDeletion?.apply { invokeExact(UMinecraft.getChatGUI(), textComponent as MCITextComponent, lineID) }
 }
+//#endif

--- a/src/main/kotlin/gg/essential/universal/wrappers/message/UTextComponent.kt
+++ b/src/main/kotlin/gg/essential/universal/wrappers/message/UTextComponent.kt
@@ -1,3 +1,5 @@
+//#if MC<12105
+@file:Suppress("DEPRECATION")
 
 package gg.essential.universal.wrappers.message
 
@@ -16,9 +18,10 @@ import net.minecraft.util.ChatComponentText
 //#endif
 
 //#if MC>=11602
+//$$ import gg.essential.universal.utils.toFormattedString
+//$$ import gg.essential.universal.utils.toUnformattedString
 //$$ import net.minecraft.util.IReorderingProcessor
 //$$ import net.minecraft.util.text.IFormattableTextComponent
-//$$ import net.minecraft.util.ICharacterConsumer
 //$$ import net.minecraft.util.text.Color
 //$$ import net.minecraft.util.text.ITextProperties.IStyledTextAcceptor
 //$$ import net.minecraft.util.text.ITextProperties.ITextAcceptor
@@ -33,6 +36,7 @@ import net.minecraft.util.ChatComponentText
 //$$ import java.util.function.Consumer
 //#endif
 
+@Deprecated("API is fairly bad and no longer works at all in 1.21.5+, just use vanilla components")
 @Suppress("MemberVisibilityCanBePrivate")
 //#if MC>=11900
 //$$ class UTextComponent : Text {
@@ -208,48 +212,6 @@ class UTextComponent : IChatComponent {
 
     private fun String.formatIf(predicate: Boolean) = if (predicate) UChat.addColor(this) else this
 
-    //#if MC>=11602
-    //$$ private class TextBuilder(private val isFormatted: Boolean) : ICharacterConsumer {
-    //$$     private val builder = StringBuilder()
-    //$$     private var cachedStyle: Style? = null
-    //$$
-    //$$     override fun accept(index: Int, style: Style, codePoint: Int): Boolean  {
-    //$$         if (isFormatted && style != cachedStyle) {
-    //$$             cachedStyle = style
-    //$$             builder.append(formatString(style))
-    //$$         }
-    //$$
-    //$$         builder.append(codePoint.toChar())
-    //$$         return true
-    //$$     }
-    //$$
-    //$$     fun getString() = builder.toString()
-    //$$
-    //$$     private fun formatString(style: Style): String {
-    //$$         val builder = StringBuilder("§r")
-    //$$
-    //$$         when {
-    //$$             style.bold -> builder.append("§l")
-    //$$             style.italic -> builder.append("§o")
-    //$$             style.underlined -> builder.append("§n")
-    //$$             style.strikethrough -> builder.append("§m")
-    //$$             style.obfuscated -> builder.append("§k")
-    //$$         }
-    //$$
-    //$$         style.color?.let(colorToFormatChar::get)?.let {
-    //$$             builder.append(it)
-    //$$         }
-    //$$         return builder.toString()
-    //$$     }
-    //$$
-    //$$     companion object {
-    //$$         private val colorToFormatChar = TextFormatting.values().mapNotNull { format ->
-    //$$             Color.fromTextFormatting(format)?.let { it to format }
-    //$$         }.toMap()
-    //$$     }
-    //$$ }
-    //#endif
-
     // **********************
     // * METHOD DELEGATIONS *
     // **********************
@@ -259,17 +221,9 @@ class UTextComponent : IChatComponent {
     //#endif
 
     //#if MC>=11602
-    //$$ val unformattedText: String get() {
-    //$$     val builder = TextBuilder(false)
-    //$$     component.func_241878_f().accept(builder)
-    //$$     return builder.getString()
-    //$$ }
+    //$$ val unformattedText: String get() = component.toUnformattedString()
     //$$
-    //$$ val formattedText: String get() {
-    //$$     val builder = TextBuilder(true)
-    //$$     component.func_241878_f().accept(builder)
-    //$$     return builder.getString()
-    //$$ }
+    //$$ val formattedText: String get() = component.toFormattedString()
     //$$
     //$$ fun appendSibling(text: ITextComponent): IFormattableTextComponent = component.append(text)
     //$$
@@ -429,3 +383,4 @@ class UTextComponent : IChatComponent {
         }
     }
 }
+//#endif

--- a/standalone/src/main/kotlin/gg/essential/universal/utils/textUtils.kt
+++ b/standalone/src/main/kotlin/gg/essential/universal/utils/textUtils.kt
@@ -1,0 +1,3 @@
+package gg.essential.universal.utils
+
+// Not applicable


### PR DESCRIPTION
Porting it to 1.21.5 while maintaining its API is difficult (actions are no longer separate from their values and those are no longer stringly typed either).

As such, this commit deprecates the class as well as the closely adjacent (and also badly designed) `UMessage` class.

For methods which are still generally useful, it introduces overloads which take the vanilla component.
`UChat.chat` was already taking `Any`, so `String` and vanilla components can simply be passed to it directly.
It also moves out the code which turns the component into a plain (formatted or unformatted) string into separate utilities because that is still very much useful (and about the only justified use-case of UTextComponent in Essential).

The only significant loss is the ability of `UMessage` to edit messages which have been posted in chat. If anyone has a use-case for that, we may re-introduce this functionality as a new, better-designed API in the future.

There doesn't appear to be any way to suppress the deprecation warnings for imports, hence why I'm using fully qualified references UTextComponent where I don't want to just suppress deprecation warnings for the entire file.