### PR TITLE
Build: Switch to `-Xjvmdefault=all` for all versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,11 +11,11 @@ plugins {
 group = "gg.essential"
 
 java.withSourcesJar()
-tasks.compileKotlin.setJvmDefault(if (platform.mcVersion >= 11400) "all" else "all-compatibility")
+tasks.compileKotlin.setJvmDefault("all")
 loom.noServerRunConfigs()
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.21")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/gg/essential/universal/shader/UShader.kt
+++ b/src/main/kotlin/gg/essential/universal/shader/UShader.kt
@@ -10,6 +10,9 @@ import gg.essential.universal.UGraphics
 //$$ import net.minecraft.client.render.Shader
 //#endif
 
+//#if MC<11600
+@JvmDefaultWithCompatibility
+//#endif
 interface UShader {
     val usable: Boolean
 

--- a/src/main/kotlin/gg/essential/universal/vertex/UVertexConsumer.kt
+++ b/src/main/kotlin/gg/essential/universal/vertex/UVertexConsumer.kt
@@ -3,6 +3,9 @@ package gg.essential.universal.vertex
 import gg.essential.universal.UMatrixStack
 import java.awt.Color
 
+//#if MC<11600
+@JvmDefaultWithCompatibility
+//#endif
 interface UVertexConsumer {
     fun pos(stack: UMatrixStack, x: Double, y: Double, z: Double): UVertexConsumer
 


### PR DESCRIPTION
Instead generating the compatibilty stubs necessary for maintaining binary compatibility on 1.12.2 and 1.8.9 via annotations on the two affected interfaces.
This way any newly introduced interfaces won't have to have the compatibility stubs any more.

Also bumps our Kotlin dependency from 1.5 to 1.6 because `JvmDefaultWithCompatibility` was only introduced in 1.6.

For details on all the jvmdefault options, see https://kotlinlang.org/docs/java-to-kotlin-interop.html#compatibility-modes-for-default-methods.