### PR TITLE
Build: Switch to `-Xjvmdefault=all` for standalone

### DIFF
--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.replaymod.gradle.preprocess.PreprocessTask
+import gg.essential.gradle.util.setJvmDefault
 
 plugins {
     kotlin("jvm")
@@ -14,6 +15,7 @@ base.archivesName = "universalcraft-standalone"
 kotlin.compilerOptions.moduleName = "universalcraft-standalone"
 publishing.publications.named<MavenPublication>("maven") { artifactId = "universalcraft-standalone" }
 java.withSourcesJar()
+tasks.compileKotlin.setJvmDefault("all")
 kotlin.jvmToolchain(8)
 
 dependencies {


### PR DESCRIPTION
Prior to this commit, the standalone project didn't use JVM default methods at all, so when code compiled against 1.8.9 (e.g. Elementa) uses a new interface which only has JVM defaults, we'll get a runtime error when ran against standalone UC.

Since we don't provide any backwards compatibliity guarantees for standalone UC, we can go straight to `all` instead of `all-compatibility` and rely on user code being re-compiled against the new version instead of having to ship compatibility shims. Interfaces which do provide the Kotlin defaults in 1.8.9 will still provide them in standalone because they're explicitly annotated as of 8f894db8.