### PR TITLE
Build: Set `FMLModType` depending on which ModLauncher version is used

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,3 +29,13 @@ preprocess {
     vars.put("STANDALONE", 0)
     vars.put("!STANDALONE", 1)
 }
+
+tasks.jar {
+    if (platform.isModLauncher) {
+        manifest {
+            // `GAMELIBRARY` is required to access Minecraft classes from ModLauncher 9 and higher.
+            val modType = if (platform.mcVersion >= 11700) "GAMELIBRARY" else "LIBRARY"
+            attributes(mapOf("FMLModType" to modType))
+        }
+    }
+}


### PR DESCRIPTION
This attribute was previously set to `LIBRARY` before 0696479 where it was removed for the following reason:
> however since we require shading and relocation on ML9 anyway,  we may as well just remove it outright.

This is fine for production, but relocation does not apply in development environments. The type should be declared as `GAMELIBRARY` on >=ML9, and `LIBRARY` on <=ML8.

Anything which uses UniversalCraft should also be on the `GAME` layer, and cannot be on any other layer (e.g. `PLUGIN`) as it will not be able to access UniversalCraft classes. This includes our other libraries (UniversalCraft, Elementa). If we want those to also be usable in development environments, we'll have to ship separate artifacts of those for >=ML9 and <=ML8 with the `FMLModType` attribute set accordingly 😢.

This PR *might* be a change that needs some more discussion, and we might want to hold off on it until we decide what to do with our other libraries (although, it probably makes sense to do either way).

Related to: #70, #73.