### PR TITLE
BlendState: Deprecate `NORMAL`

### DIFF
--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -1121,9 +1121,11 @@ public final class gg/essential/universal/render/URenderPipeline$DepthTest : jav
 }
 
 public final class gg/essential/universal/shader/BlendState {
+	public static final field ALPHA Lgg/essential/universal/shader/BlendState;
 	public static final field Companion Lgg/essential/universal/shader/BlendState$Companion;
 	public static final field DISABLED Lgg/essential/universal/shader/BlendState;
 	public static final field NORMAL Lgg/essential/universal/shader/BlendState;
+	public static final field PREMULTIPLIED_ALPHA Lgg/essential/universal/shader/BlendState;
 	public fun <init> (Lgg/essential/universal/shader/BlendState$Equation;Lgg/essential/universal/shader/BlendState$Param;Lgg/essential/universal/shader/BlendState$Param;Lgg/essential/universal/shader/BlendState$Param;Lgg/essential/universal/shader/BlendState$Param;Z)V
 	public synthetic fun <init> (Lgg/essential/universal/shader/BlendState$Equation;Lgg/essential/universal/shader/BlendState$Param;Lgg/essential/universal/shader/BlendState$Param;Lgg/essential/universal/shader/BlendState$Param;Lgg/essential/universal/shader/BlendState$Param;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun activate ()V

--- a/src/main/kotlin/gg/essential/universal/shader/BlendState.kt
+++ b/src/main/kotlin/gg/essential/universal/shader/BlendState.kt
@@ -75,7 +75,12 @@ data class BlendState(
         @JvmField
         val DISABLED = BlendState(Equation.ADD, Param.ONE, Param.ZERO, enabled = false)
         @JvmField
+        @Deprecated("Produces incorrect results when rendering on a non-opaque background.", ReplaceWith("ALPHA"))
         val NORMAL = BlendState(Equation.ADD, Param.SRC_ALPHA, Param.ONE_MINUS_SRC_ALPHA)
+        @JvmField
+        val ALPHA = BlendState(Equation.ADD, Param.SRC_ALPHA, Param.ONE_MINUS_SRC_ALPHA, Param.ONE, Param.ONE_MINUS_SRC_ALPHA)
+        @JvmField
+        val PREMULTIPLIED_ALPHA = BlendState(Equation.ADD, Param.ONE, Param.ONE_MINUS_SRC_ALPHA)
 
         @JvmStatic
         fun active() = BlendState(

--- a/standalone/src/main/kotlin/gg/essential/universal/standalone/render/DefaultShader.kt
+++ b/standalone/src/main/kotlin/gg/essential/universal/standalone/render/DefaultShader.kt
@@ -23,7 +23,7 @@ internal class DefaultShader(val shader: UShader) {
                 val shader = UShader.fromLegacyShader(
                     genVertexShaderSource(texture, color),
                     genFragmentShaderSource(texture, color),
-                    BlendState.NORMAL,
+                    BlendState.ALPHA,
                     attributes,
                 )
                 DefaultShader(shader)


### PR DESCRIPTION
Its alpha result part (which isn't specified explicitly, so matches the rgb result part) doesn't make any sense.

`dst` is the color of the render target / framebuffer, `src` is the color of the thing being rendered.
`BlendState.NORMAL` is
`result.rgb = src.rgb * src.a + dst.rgb * (1-src.a)`
`result.a = src.a * src.a + dst.a * (1-src.a)`
The rgb part makes sense if you're working with regular alpha blending.
However the alpha part does not because it means that if you e.g. draw a 50% opaque quad (`src.a = 0.5`) on a fully opaque background (`dst.a = 1`), you'll suddenly end up with a partially translucent framebuffer (`result.a = 0.5 * 0.5 + 1 * (1-0.5) = 0.25 + 0.5 = 0.75`), even though we'd expect it to be opaque given the previous background was already opaque.
Similarly you get incorrect results rendering a 50% opaque quad on a 50% opaque background; you'd expect the combination to be 75% opaque (`result.a = 0.75`) but it's actually just 50% opaque (`result.a = 0.5 * 0.5 + 0.5 * (1 - 0.5) = 0.25 + 0.25 = 0.5`).

The correct equation to use is `result.a = src.a * 1 + dst.a * (1-src.a)` (which makes sense if you think of alpha as "how much it obscures the background").
In the first scenario this gives `result.a = 0.5 * 1 + 1 * (1-0.5) = 0.5 + 0.5 = 1` as expected.
In the second scenario this gives `result.a = 0.5 * 1 + 0.5 * (1-0.5) = 0.5 + 0.25 = 0.75` as expected.

This PR therefore deprecates `BlendState.NORMAL` in favor of a new `BlendState.ALPHA` which uses the correct blending (I've called it `ALPHA` because it's standard "alpha blending"; considered using `DEFAULT` but that might be confusing because MC only started using it [with 1.16](https://i.johni0702.de/Heudr.png), while older versions [apparently didn't really know what they were doing either](https://i.johni0702.de/q7946.png)).

This PR also adds a `BlendState.PREMULTIPLIED_ALPHA` which takes the same equation parameters and also applies them to the rgb part. This is a generally superior way of doing blending (e.g. it works correctly when compositing different partially translucent intermediate render results), despite it being not as well known as conventional blending. See these blog posts for explanations: [1] [2] [3]

[1]: https://shawnhargreaves.com/blog/premultiplied-alpha.html
[2]: https://shawnhargreaves.com/blog/texture-filtering-alpha-cutouts.html
[3]: https://shawnhargreaves.com/blog/premultiplied-alpha-and-image-composition.html