### PR TITLE
Build: Port to 1.21.6 Fabric

### DIFF
--- a/api/UniversalCraft.api
+++ b/api/UniversalCraft.api
@@ -90,14 +90,14 @@ public class gg/essential/universal/UGraphics {
 	public static field EMPTY_WITH_FONT_ID Lnet/minecraft/network/chat/Style;
 	@1.16.2-forge
 	public static field EMPTY_WITH_FONT_ID Lnet/minecraft/util/text/Style;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static field EMPTY_WITH_FONT_ID Lnet/minecraft/text/Style;
 	public static field ZERO_TEXT_ALPHA I
 	@1.8.9-forge
 	public fun <init> (Lnet/minecraft/client/renderer/WorldRenderer;)V
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public fun <init> (Lcom/mojang/blaze3d/vertex/BufferBuilder;)V
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public fun <init> (Lnet/minecraft/client/render/BufferBuilder;)V
 	@1.12.2-forge,1.16.2-forge
 	public fun <init> (Lnet/minecraft/client/renderer/BufferBuilder;)V
@@ -105,21 +105,21 @@ public class gg/essential/universal/UGraphics {
 	public static fun alphaFunc (IF)V
 	public static fun areShadersSupported ()Z
 	public fun asUVertexConsumer ()Lgg/essential/universal/vertex/UVertexConsumer;
-	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public fun begin (ILcom/mojang/blaze3d/vertex/VertexFormat;)Lgg/essential/universal/UGraphics;
 	public fun begin (ILgg/essential/universal/UGraphics$CommonVertexFormats;)Lgg/essential/universal/UGraphics;
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
 	public fun begin (ILnet/minecraft/client/render/VertexFormat;)Lgg/essential/universal/UGraphics;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public fun beginRenderLayer (Lnet/minecraft/client/render/RenderLayer;)Lgg/essential/universal/UGraphics;
 	@1.12.2-forge,1.16.2-forge,1.8.9-forge
 	public fun begin (ILnet/minecraft/client/renderer/vertex/VertexFormat;)Lgg/essential/universal/UGraphics;
 	@1.16.2-forge,1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public fun beginRenderLayer (Lnet/minecraft/client/renderer/RenderType;)Lgg/essential/universal/UGraphics;
-	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public fun beginWithActiveShader (Lgg/essential/universal/UGraphics$DrawMode;Lcom/mojang/blaze3d/vertex/VertexFormat;)Lgg/essential/universal/UGraphics;
 	public fun beginWithActiveShader (Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;)Lgg/essential/universal/UGraphics;
-	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public fun beginWithDefaultShader (Lgg/essential/universal/UGraphics$DrawMode;Lcom/mojang/blaze3d/vertex/VertexFormat;)Lgg/essential/universal/UGraphics;
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
 	public fun beginWithActiveShader (Lgg/essential/universal/UGraphics$DrawMode;Lnet/minecraft/client/render/VertexFormat;)Lgg/essential/universal/UGraphics;
@@ -136,9 +136,9 @@ public class gg/essential/universal/UGraphics {
 	public static fun bindTexture (ILnet/minecraft/resources/ResourceLocation;)V
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public static fun bindTexture (Lnet/minecraft/resources/ResourceLocation;)V
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static fun bindTexture (ILnet/minecraft/util/Identifier;)V
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static fun bindTexture (Lnet/minecraft/util/Identifier;)V
 	@1.12.2-forge,1.16.2-forge,1.8.9-forge
 	public static fun bindTexture (ILnet/minecraft/util/ResourceLocation;)V
@@ -190,7 +190,7 @@ public class gg/essential/universal/UGraphics {
 	public static fun getStringWidth (Ljava/lang/String;)I
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public static fun getTessellator ()Lcom/mojang/blaze3d/vertex/Tesselator;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static fun getTessellator ()Lnet/minecraft/client/render/Tessellator;
 	@1.12.2-forge,1.16.2-forge,1.8.9-forge
 	public static fun getTessellator ()Lnet/minecraft/client/renderer/Tessellator;
@@ -249,7 +249,7 @@ public final class gg/essential/universal/UGraphics$CommonVertexFormats : java/l
 	public static final field POSITION_TEXTURE_COLOR_LIGHT Lgg/essential/universal/UGraphics$CommonVertexFormats;
 	public static final field POSITION_TEXTURE_COLOR_NORMAL Lgg/essential/universal/UGraphics$CommonVertexFormats;
 	public static final field POSITION_TEXTURE_LIGHT_COLOR Lgg/essential/universal/UGraphics$CommonVertexFormats;
-	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public final field mc Lcom/mojang/blaze3d/vertex/VertexFormat;
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
 	public final field mc Lnet/minecraft/client/render/VertexFormat;
@@ -267,7 +267,7 @@ public final class gg/essential/universal/UGraphics$DrawMode : java/lang/Enum {
 	public static final field TRIANGLE_FAN Lgg/essential/universal/UGraphics$DrawMode;
 	public static final field TRIANGLE_STRIP Lgg/essential/universal/UGraphics$DrawMode;
 	public final field glMode I
-	@1.21.5-fabric
+	@1.21.5-fabric,1.21.6-fabric
 	public final field mcMode Lcom/mojang/blaze3d/vertex/VertexFormat$DrawMode;
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public final field mcMode Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;
@@ -278,7 +278,7 @@ public final class gg/essential/universal/UGraphics$DrawMode : java/lang/Enum {
 	public static fun fromGl (I)Lgg/essential/universal/UGraphics$DrawMode;
 	@1.16.2-forge,1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public static fun fromRenderLayer (Lnet/minecraft/client/renderer/RenderType;)Lgg/essential/universal/UGraphics$DrawMode;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static fun fromRenderLayer (Lnet/minecraft/client/render/RenderLayer;)Lgg/essential/universal/UGraphics$DrawMode;
 	public static fun valueOf (Ljava/lang/String;)Lgg/essential/universal/UGraphics$DrawMode;
 	public static fun values ()[Lgg/essential/universal/UGraphics$DrawMode;
@@ -344,9 +344,9 @@ public final class gg/essential/universal/UGuiButton {
 	public static final fun getX (Lnet/minecraft/client/gui/components/AbstractWidget;)I
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public static final fun getY (Lnet/minecraft/client/gui/components/AbstractWidget;)I
-	@1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun getX (Lnet/minecraft/client/gui/widget/ClickableWidget;)I
-	@1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun getY (Lnet/minecraft/client/gui/widget/ClickableWidget;)I
 	@1.16.2-forge
 	public static final fun getX (Lnet/minecraft/client/gui/widget/Widget;)I
@@ -373,7 +373,7 @@ public final class gg/essential/universal/UImage {
 	public fun <init> (Lcom/mojang/blaze3d/platform/NativeImage;)V
 	@1.16.2-forge
 	public fun <init> (Lnet/minecraft/client/renderer/texture/NativeImage;)V
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public fun <init> (Lnet/minecraft/client/texture/NativeImage;)V
 	@1.12.2-forge,1.8.9-forge
 	public fun <init> (Ljava/awt/image/BufferedImage;)V
@@ -384,7 +384,7 @@ public final class gg/essential/universal/UImage {
 	public final fun getNativeImage ()Lcom/mojang/blaze3d/platform/NativeImage;
 	@1.16.2-forge
 	public final fun getNativeImage ()Lnet/minecraft/client/renderer/texture/NativeImage;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public final fun getNativeImage ()Lnet/minecraft/client/texture/NativeImage;
 	@1.12.2-forge,1.8.9-forge
 	public final fun getNativeImage ()Ljava/awt/image/BufferedImage;
@@ -514,7 +514,7 @@ public final class gg/essential/universal/UKeyboard {
 	public static final fun getKeyName (II)Ljava/lang/String;
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public static final fun getKeyName (Lnet/minecraft/client/KeyMapping;)Ljava/lang/String;
-	@1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun getKeyName (Lnet/minecraft/client/option/KeyBinding;)Ljava/lang/String;
 	@1.16.2-fabric
 	public static final fun getKeyName (Lnet/minecraft/client/options/KeyBinding;)Ljava/lang/String;
@@ -569,14 +569,16 @@ public final class gg/essential/universal/UMatrixStack {
 	public fun <init> (Lcom/mojang/blaze3d/matrix/MatrixStack$Entry;)V
 	@1.16.2-forge
 	public fun <init> (Lcom/mojang/blaze3d/matrix/MatrixStack;)V
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public fun <init> (Lnet/minecraft/client/util/math/MatrixStack$Entry;)V
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public fun <init> (Lnet/minecraft/client/util/math/MatrixStack;)V
+	@1.21.6-fabric
+	public fun <init> (Lorg/joml/Matrix3x2f;)V
 	public final fun applyToGlobalState ()V
 	public final fun fork ()Lgg/essential/universal/UMatrixStack;
 	public final fun isEmpty ()Z
-	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public final fun multiply (Lorg/joml/Quaternionf;)V
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge
 	public final fun multiply (Lcom/mojang/math/Quaternion;)V
@@ -599,11 +601,15 @@ public final class gg/essential/universal/UMatrixStack {
 	public final fun runWithGlobalState (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public final fun scale (DDD)V
 	public final fun scale (FFF)V
+	@1.21.6-fabric
+	public final fun to3x2Joml (Lorg/joml/Matrix3x2f;)Lorg/joml/Matrix3x2f;
+	@1.21.6-fabric
+	public static synthetic fun to3x2Joml$default (Lgg/essential/universal/UMatrixStack;Lorg/joml/Matrix3x2f;ILjava/lang/Object;)Lorg/joml/Matrix3x2f;
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public final fun toMC ()Lcom/mojang/blaze3d/vertex/PoseStack;
 	@1.16.2-forge
 	public final fun toMC ()Lcom/mojang/blaze3d/matrix/MatrixStack;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public final fun toMC ()Lnet/minecraft/client/util/math/MatrixStack;
 	public final fun translate (DDD)V
 	public final fun translate (FFF)V
@@ -620,15 +626,15 @@ public final class gg/essential/universal/UMatrixStack$Compat {
 }
 
 public final class gg/essential/universal/UMatrixStack$Entry {
-	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public fun <init> (Lorg/joml/Matrix4f;Lorg/joml/Matrix3f;)V
-	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public final fun component1 ()Lorg/joml/Matrix4f;
-	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public final fun component2 ()Lorg/joml/Matrix3f;
-	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public final fun copy (Lorg/joml/Matrix4f;Lorg/joml/Matrix3f;)Lgg/essential/universal/UMatrixStack$Entry;
-	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public static synthetic fun copy$default (Lgg/essential/universal/UMatrixStack$Entry;Lorg/joml/Matrix4f;Lorg/joml/Matrix3f;ILjava/lang/Object;)Lgg/essential/universal/UMatrixStack$Entry;
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge
 	public fun <init> (Lcom/mojang/math/Matrix4f;Lcom/mojang/math/Matrix3f;)V
@@ -672,7 +678,7 @@ public final class gg/essential/universal/UMatrixStack$Entry {
 	public static synthetic fun copy$default (Lgg/essential/universal/UMatrixStack$Entry;Lorg/lwjgl/util/vector/Matrix4f;Lorg/lwjgl/util/vector/Matrix3f;ILjava/lang/Object;)Lgg/essential/universal/UMatrixStack$Entry;
 	public final fun deepCopy ()Lgg/essential/universal/UMatrixStack$Entry;
 	public fun equals (Ljava/lang/Object;)Z
-	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public final fun getModel ()Lorg/joml/Matrix4f;
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge
 	public final fun getModel ()Lcom/mojang/math/Matrix4f;
@@ -683,7 +689,7 @@ public final class gg/essential/universal/UMatrixStack$Entry {
 	@1.12.2-forge,1.8.9-forge
 	public final fun getModel ()Lorg/lwjgl/util/vector/Matrix4f;
 	public final fun getModelAsArray ()[F
-	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.19.3-fabric,1.19.3-forge,1.19.4-fabric,1.19.4-forge,1.20-fabric,1.20.1-fabric,1.20.1-forge,1.20.2-fabric,1.20.2-forge,1.20.4-fabric,1.20.4-forge,1.20.4-neoforge,1.20.6-fabric,1.20.6-forge,1.20.6-neoforge,1.21-fabric,1.21-forge,1.21-neoforge,1.21.3-fabric,1.21.3-forge,1.21.3-neoforge,1.21.4-fabric,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public final fun getNormal ()Lorg/joml/Matrix3f;
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge
 	public final fun getNormal ()Lcom/mojang/math/Matrix3f;
@@ -698,7 +704,7 @@ public final class gg/essential/universal/UMatrixStack$Entry {
 	public final fun toMCStack ()Lcom/mojang/blaze3d/vertex/PoseStack;
 	@1.16.2-forge
 	public final fun toMCStack ()Lcom/mojang/blaze3d/matrix/MatrixStack;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public final fun toMCStack ()Lnet/minecraft/client/util/math/MatrixStack;
 	public fun toString ()Ljava/lang/String;
 }
@@ -710,25 +716,25 @@ public final class gg/essential/universal/UMinecraft {
 	public static final fun getChatGUI ()Lnet/minecraft/client/gui/components/ChatComponent;
 	@1.16.2-forge
 	public static final fun getChatGUI ()Lnet/minecraft/client/gui/NewChatGui;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun getChatGUI ()Lnet/minecraft/client/gui/hud/ChatHud;
 	@1.12.2-forge,1.8.9-forge
 	public static final fun getChatGUI ()Lnet/minecraft/client/gui/GuiNewChat;
 	public static final fun getCurrentScreenObj ()Ljava/lang/Object;
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public static final fun getFontRenderer ()Lnet/minecraft/client/gui/Font;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun getFontRenderer ()Lnet/minecraft/client/font/TextRenderer;
 	@1.12.2-forge,1.16.2-forge,1.8.9-forge
 	public static final fun getFontRenderer ()Lnet/minecraft/client/gui/FontRenderer;
 	public static final fun getGuiScale ()I
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun getMinecraft ()Lnet/minecraft/client/MinecraftClient;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun getNetHandler ()Lnet/minecraft/client/network/ClientPlayNetworkHandler;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun getPlayer ()Lnet/minecraft/client/network/ClientPlayerEntity;
-	@1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun getSettings ()Lnet/minecraft/client/option/GameOptions;
 	@1.16.2-fabric
 	public static final fun getSettings ()Lnet/minecraft/client/options/GameOptions;
@@ -755,7 +761,7 @@ public final class gg/essential/universal/UMinecraft {
 	public static final fun getTime ()J
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public static final fun getWorld ()Lnet/minecraft/client/multiplayer/ClientLevel;
-	@1.16.2-fabric,1.16.2-forge,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.16.2-forge,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun getWorld ()Lnet/minecraft/client/world/ClientWorld;
 	@1.12.2-forge,1.8.9-forge
 	public static final fun getWorld ()Lnet/minecraft/client/multiplayer/WorldClient;
@@ -792,7 +798,7 @@ public final class gg/essential/universal/UPacket {
 	public static final fun sendActionBarMessage (Lnet/minecraft/util/IChatComponent;)V
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public static final fun sendActionBarMessage (Lnet/minecraft/network/chat/Component;)V
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun sendActionBarMessage (Lnet/minecraft/text/Text;)V
 	@1.12.2-forge,1.16.2-forge
 	public static final fun sendActionBarMessage (Lnet/minecraft/util/text/ITextComponent;)V
@@ -802,7 +808,7 @@ public final class gg/essential/universal/UPacket {
 	public static final fun sendChatMessage (Lnet/minecraft/util/IChatComponent;)V
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public static final fun sendChatMessage (Lnet/minecraft/network/chat/Component;)V
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun sendChatMessage (Lnet/minecraft/text/Text;)V
 	@1.12.2-forge,1.16.2-forge
 	public static final fun sendChatMessage (Lnet/minecraft/util/text/ITextComponent;)V
@@ -880,7 +886,7 @@ public abstract class gg/essential/universal/UScreen : net/minecraft/client/gui/
 	public fun updateGuiScale ()V
 }
 
-@1.16.2-fabric,1.16.2-forge,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+@1.16.2-fabric,1.16.2-forge,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 public abstract class gg/essential/universal/UScreen : net/minecraft/client/gui/screen/Screen {
 	public static final field Companion Lgg/essential/universal/UScreen$Companion;
 	public fun <init> ()V
@@ -897,7 +903,7 @@ public abstract class gg/essential/universal/UScreen : net/minecraft/client/gui/
 	public final fun getRestoreCurrentGuiOnClose ()Z
 	@1.16.2-forge
 	public fun getTitle ()Lnet/minecraft/util/text/ITextComponent;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public fun getTitle ()Lnet/minecraft/text/Text;
 	public fun getUnlocalizedName ()Ljava/lang/String;
 	protected final fun init ()V
@@ -907,7 +913,7 @@ public abstract class gg/essential/universal/UScreen : net/minecraft/client/gui/
 	public final fun mouseClicked (DDI)Z
 	public final fun mouseDragged (DDIDD)Z
 	public final fun mouseReleased (DDI)Z
-	@1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public fun mouseScrolled (DDDD)Z
 	@1.16.2-fabric,1.16.2-forge,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric
 	public final fun mouseScrolled (DDD)Z
@@ -930,11 +936,11 @@ public abstract class gg/essential/universal/UScreen : net/minecraft/client/gui/
 	public final fun render (Lcom/mojang/blaze3d/matrix/MatrixStack;IIF)V
 	@1.16.2-forge
 	public final fun renderBackground (Lcom/mojang/blaze3d/matrix/MatrixStack;I)V
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public final fun removed ()V
-	@1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public final fun render (Lnet/minecraft/client/gui/DrawContext;IIF)V
-	@1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public final fun renderBackground (Lnet/minecraft/client/gui/DrawContext;IIF)V
 	@1.20-fabric,1.20.1-fabric
 	public final fun renderBackground (Lnet/minecraft/client/gui/DrawContext;)V
@@ -1001,9 +1007,9 @@ public final class gg/essential/universal/UScreen$Companion {
 	public final fun displayScreen (Lnet/minecraft/client/gui/screens/Screen;)V
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public final fun getCurrentScreen ()Lnet/minecraft/client/gui/screens/Screen;
-	@1.16.2-fabric,1.16.2-forge,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.16.2-forge,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public final fun displayScreen (Lnet/minecraft/client/gui/screen/Screen;)V
-	@1.16.2-fabric,1.16.2-forge,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.16.2-forge,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public final fun getCurrentScreen ()Lnet/minecraft/client/gui/screen/Screen;
 	@1.12.2-forge,1.8.9-forge
 	public final fun displayScreen (Lnet/minecraft/client/gui/GuiScreen;)V
@@ -1023,11 +1029,11 @@ public final class gg/essential/universal/USound {
 	public final fun playSoundStatic (Lnet/minecraft/util/ResourceLocation;FF)V
 	@1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public final fun playSoundStatic (Lnet/minecraft/core/Holder;FF)V
-	@1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public final fun playSoundStatic (Lnet/minecraft/registry/entry/RegistryEntry;FF)V
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public final fun playSoundStatic (Lnet/minecraft/sounds/SoundEvent;FF)V
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public final fun playSoundStatic (Lnet/minecraft/sound/SoundEvent;FF)V
 	@1.12.2-forge,1.16.2-forge
 	public final fun playSoundStatic (Lnet/minecraft/util/SoundEvent;FF)V
@@ -1045,16 +1051,18 @@ public abstract interface class gg/essential/universal/render/DrawCallBuilder {
 public final class gg/essential/universal/render/URenderPipeline {
 	public static final field Companion Lgg/essential/universal/render/URenderPipeline$Companion;
 	@1.21.5-forge,1.21.5-neoforge
-	public synthetic fun <init> (Lnet/minecraft/resources/ResourceLocation;Lcom/mojang/blaze3d/vertex/VertexFormat;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Ljava/util/function/BiFunction;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	@1.21.5-fabric
-	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lcom/mojang/blaze3d/vertex/VertexFormat;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Ljava/util/function/BiFunction;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lnet/minecraft/resources/ResourceLocation;Lcom/mojang/blaze3d/vertex/VertexFormat;Ljava/util/function/BiFunction;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	@1.21.5-fabric,1.21.6-fabric
+	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lcom/mojang/blaze3d/vertex/VertexFormat;Ljava/util/function/BiFunction;Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge
-	public synthetic fun <init> (Lnet/minecraft/resources/ResourceLocation;Lcom/mojang/blaze3d/vertex/VertexFormat;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Lgg/essential/universal/render/ManagedGlState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lnet/minecraft/resources/ResourceLocation;Lcom/mojang/blaze3d/vertex/VertexFormat;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Lgg/essential/universal/render/ManagedGlState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
-	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lnet/minecraft/client/render/VertexFormat;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Lgg/essential/universal/render/ManagedGlState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lnet/minecraft/util/Identifier;Lnet/minecraft/client/render/VertexFormat;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Lgg/essential/universal/render/ManagedGlState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	@1.12.2-forge,1.16.2-forge,1.8.9-forge
-	public synthetic fun <init> (Lnet/minecraft/util/ResourceLocation;Lnet/minecraft/client/renderer/vertex/VertexFormat;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Lgg/essential/universal/render/ManagedGlState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lnet/minecraft/util/ResourceLocation;Lnet/minecraft/client/renderer/vertex/VertexFormat;Lgg/essential/universal/render/URenderPipeline$ShaderSupplier;Lgg/essential/universal/render/ManagedGlState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun toString ()Ljava/lang/String;
+	@1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
+	public static final fun wrap (Lcom/mojang/blaze3d/pipeline/RenderPipeline;)Lgg/essential/universal/render/URenderPipeline;
 }
 
 public abstract interface class gg/essential/universal/render/URenderPipeline$Builder : gg/essential/universal/render/URenderPipeline$BuilderProps {
@@ -1088,7 +1096,7 @@ public final class gg/essential/universal/render/URenderPipeline$ColorLogic : ja
 public final class gg/essential/universal/render/URenderPipeline$Companion {
 	@1.21.5-forge,1.21.5-neoforge
 	public final fun builder (Lnet/minecraft/resources/ResourceLocation;Lgg/essential/universal/UGraphics$DrawMode;Lcom/mojang/blaze3d/vertex/VertexFormat;Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/resources/ResourceLocation;Ljava/util/List;Ljava/util/Map;)Lgg/essential/universal/render/URenderPipeline$Builder;
-	@1.21.5-fabric
+	@1.21.5-fabric,1.21.6-fabric
 	public final fun builder (Lnet/minecraft/util/Identifier;Lgg/essential/universal/UGraphics$DrawMode;Lcom/mojang/blaze3d/vertex/VertexFormat;Lnet/minecraft/util/Identifier;Lnet/minecraft/util/Identifier;Ljava/util/List;Ljava/util/Map;)Lgg/essential/universal/render/URenderPipeline$Builder;
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge
 	public final fun builder (Lnet/minecraft/resources/ResourceLocation;Lgg/essential/universal/UGraphics$DrawMode;Lcom/mojang/blaze3d/vertex/VertexFormat;Ljava/util/function/Supplier;)Lgg/essential/universal/render/URenderPipeline$Builder;
@@ -1099,7 +1107,7 @@ public final class gg/essential/universal/render/URenderPipeline$Companion {
 	@1.21.3-fabric,1.21.4-fabric
 	public final fun builder (Lnet/minecraft/util/Identifier;Lgg/essential/universal/UGraphics$DrawMode;Lnet/minecraft/client/render/VertexFormat;Lnet/minecraft/client/gl/ShaderProgramKey;)Lgg/essential/universal/render/URenderPipeline$Builder;
 	public final fun builderWithDefaultShader (Ljava/lang/String;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;)Lgg/essential/universal/render/URenderPipeline$Builder;
-	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public final fun builderWithLegacyShader (Ljava/lang/String;Lgg/essential/universal/UGraphics$DrawMode;Lcom/mojang/blaze3d/vertex/VertexFormat;Ljava/lang/String;Ljava/lang/String;)Lgg/essential/universal/render/URenderPipeline$Builder;
 	public final fun builderWithLegacyShader (Ljava/lang/String;Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;Ljava/lang/String;Ljava/lang/String;)Lgg/essential/universal/render/URenderPipeline$Builder;
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
@@ -1107,6 +1115,8 @@ public final class gg/essential/universal/render/URenderPipeline$Companion {
 	@1.12.2-forge,1.16.2-forge,1.8.9-forge
 	public final fun builderWithLegacyShader (Ljava/lang/String;Lgg/essential/universal/UGraphics$DrawMode;Lnet/minecraft/client/renderer/vertex/VertexFormat;Ljava/lang/String;Ljava/lang/String;)Lgg/essential/universal/render/URenderPipeline$Builder;
 	public final fun isRequired ()Z
+	@1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
+	public final fun wrap (Lcom/mojang/blaze3d/pipeline/RenderPipeline;)Lgg/essential/universal/render/URenderPipeline;
 }
 
 public final class gg/essential/universal/render/URenderPipeline$DepthTest : java/lang/Enum {
@@ -1286,7 +1296,7 @@ public final class gg/essential/universal/utils/ReleasedDynamicTexture : net/min
 	public final fun uploadTexture ()V
 }
 
-@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 public final class gg/essential/universal/utils/ReleasedDynamicTexture : net/minecraft/client/texture/AbstractTexture {
 	public fun <init> (II)V
 	public fun <init> (Lnet/minecraft/client/texture/NativeImage;)V
@@ -1294,20 +1304,24 @@ public final class gg/essential/universal/utils/ReleasedDynamicTexture : net/min
 	public fun clearGlId ()V
 	public fun close ()V
 	public final fun getDynamicGlId ()I
-	@1.21.5-fabric
+	@1.21.5-fabric,1.21.6-fabric
 	public fun getGlTexture ()Lcom/mojang/blaze3d/textures/GpuTexture;
+	@1.21.6-fabric
+	public fun getGlTextureView ()Lcom/mojang/blaze3d/textures/GpuTextureView;
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
 	public fun getGlId ()I
 	public final fun getHeight ()I
 	public final fun getUploaded ()Z
 	public final fun getWidth ()I
-	@1.21.5-fabric
+	@1.21.5-fabric,1.21.6-fabric
 	public fun setClamp (Z)V
-	@1.21.5-fabric
+	@1.21.5-fabric,1.21.6-fabric
 	public fun setFilter (ZZ)V
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric
 	public fun load (Lnet/minecraft/resource/ResourceManager;)V
 	public final fun setUploaded (Z)V
+	@1.21.6-fabric
+	public fun setUseMipmaps (Z)V
 	public final fun updateDynamicTexture ()V
 	public final fun uploadTexture ()V
 }
@@ -1372,9 +1386,9 @@ public final class gg/essential/universal/utils/TextUtilsKt {
 	public static final fun toFormattedString (Lnet/minecraft/network/chat/Component;)Ljava/lang/String;
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public static final fun toUnformattedString (Lnet/minecraft/network/chat/Component;)Ljava/lang/String;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun toFormattedString (Lnet/minecraft/text/Text;)Ljava/lang/String;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun toUnformattedString (Lnet/minecraft/text/Text;)Ljava/lang/String;
 	@1.12.2-forge,1.16.2-forge
 	public static final fun toFormattedString (Lnet/minecraft/util/text/ITextComponent;)Ljava/lang/String;
@@ -1385,7 +1399,7 @@ public final class gg/essential/universal/utils/TextUtilsKt {
 public abstract interface class gg/essential/universal/vertex/UBufferBuilder : gg/essential/universal/vertex/UVertexConsumer {
 	public static final field Companion Lgg/essential/universal/vertex/UBufferBuilder$Companion;
 	public abstract fun build ()Lgg/essential/universal/vertex/UBuiltBuffer;
-	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public static fun create (Lgg/essential/universal/UGraphics$DrawMode;Lcom/mojang/blaze3d/vertex/VertexFormat;)Lgg/essential/universal/vertex/UBufferBuilder;
 	public static fun create (Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;)Lgg/essential/universal/vertex/UBufferBuilder;
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
@@ -1395,7 +1409,7 @@ public abstract interface class gg/essential/universal/vertex/UBufferBuilder : g
 }
 
 public final class gg/essential/universal/vertex/UBufferBuilder$Companion {
-	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge
+	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-fabric,1.21.5-forge,1.21.5-neoforge,1.21.6-fabric
 	public final fun create (Lgg/essential/universal/UGraphics$DrawMode;Lcom/mojang/blaze3d/vertex/VertexFormat;)Lgg/essential/universal/vertex/UBufferBuilder;
 	public final fun create (Lgg/essential/universal/UGraphics$DrawMode;Lgg/essential/universal/UGraphics$CommonVertexFormats;)Lgg/essential/universal/vertex/UBufferBuilder;
 	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric
@@ -1409,20 +1423,20 @@ public abstract interface class gg/essential/universal/vertex/UBuiltBuffer : jav
 	public fun draw (Lgg/essential/universal/render/URenderPipeline;Lkotlin/jvm/functions/Function1;)V
 	@1.16.2-forge,1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public fun draw (Lnet/minecraft/client/renderer/RenderType;)V
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public fun draw (Lnet/minecraft/client/render/RenderLayer;)V
 	public static synthetic fun draw$default (Lgg/essential/universal/vertex/UBuiltBuffer;Lgg/essential/universal/render/URenderPipeline;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public fun drawAndClose (Lgg/essential/universal/render/URenderPipeline;Lkotlin/jvm/functions/Function1;)V
 	@1.16.2-forge,1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public fun drawAndClose (Lnet/minecraft/client/renderer/RenderType;)V
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public fun drawAndClose (Lnet/minecraft/client/render/RenderLayer;)V
 	public static synthetic fun drawAndClose$default (Lgg/essential/universal/vertex/UBuiltBuffer;Lgg/essential/universal/render/URenderPipeline;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	@1.8.9-forge
 	public static fun wrap (Lnet/minecraft/client/renderer/WorldRenderer;)Lgg/essential/universal/vertex/UBuiltBuffer;
 	@1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public static fun wrap (Lcom/mojang/blaze3d/vertex/MeshData;)Lgg/essential/universal/vertex/UBuiltBuffer;
-	@1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static fun wrap (Lnet/minecraft/client/render/BuiltBuffer;)Lgg/essential/universal/vertex/UBuiltBuffer;
 	@1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge
 	public static fun wrap (Lcom/mojang/blaze3d/vertex/BufferBuilder$RenderedBuffer;)Lgg/essential/universal/vertex/UBuiltBuffer;
@@ -1441,7 +1455,7 @@ public final class gg/essential/universal/vertex/UBuiltBuffer$Companion {
 	public final fun wrap (Lnet/minecraft/client/renderer/WorldRenderer;)Lgg/essential/universal/vertex/UBuiltBuffer;
 	@1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public final fun wrap (Lcom/mojang/blaze3d/vertex/MeshData;)Lgg/essential/universal/vertex/UBuiltBuffer;
-	@1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public final fun wrap (Lnet/minecraft/client/render/BuiltBuffer;)Lgg/essential/universal/vertex/UBuiltBuffer;
 	@1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge
 	public final fun wrap (Lcom/mojang/blaze3d/vertex/BufferBuilder$RenderedBuffer;)Lgg/essential/universal/vertex/UBuiltBuffer;
@@ -1469,7 +1483,7 @@ public abstract interface class gg/essential/universal/vertex/UVertexConsumer {
 	public static fun of (Lcom/mojang/blaze3d/vertex/VertexConsumer;)Lgg/essential/universal/vertex/UVertexConsumer;
 	@1.16.2-forge
 	public static fun of (Lcom/mojang/blaze3d/vertex/IVertexBuilder;)Lgg/essential/universal/vertex/UVertexConsumer;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static fun of (Lnet/minecraft/client/render/VertexConsumer;)Lgg/essential/universal/vertex/UVertexConsumer;
 	@1.12.2-forge
 	public static fun of (Lnet/minecraft/client/renderer/BufferBuilder;)Lgg/essential/universal/vertex/UVertexConsumer;
@@ -1485,7 +1499,7 @@ public final class gg/essential/universal/vertex/UVertexConsumer$Companion {
 	public final fun of (Lcom/mojang/blaze3d/vertex/VertexConsumer;)Lgg/essential/universal/vertex/UVertexConsumer;
 	@1.16.2-forge
 	public final fun of (Lcom/mojang/blaze3d/vertex/IVertexBuilder;)Lgg/essential/universal/vertex/UVertexConsumer;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public final fun of (Lnet/minecraft/client/render/VertexConsumer;)Lgg/essential/universal/vertex/UVertexConsumer;
 	@1.12.2-forge
 	public final fun of (Lnet/minecraft/client/renderer/BufferBuilder;)Lgg/essential/universal/vertex/UVertexConsumer;
@@ -1503,7 +1517,7 @@ public final class gg/essential/universal/wrappers/UPlayer {
 	public static final fun getPlayer ()Lnet/minecraft/client/player/LocalPlayer;
 	@1.16.2-forge
 	public static final fun getPlayer ()Lnet/minecraft/client/entity/player/ClientPlayerEntity;
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun getPlayer ()Lnet/minecraft/client/network/ClientPlayerEntity;
 	@1.12.2-forge,1.8.9-forge
 	public static final fun getPlayer ()Lnet/minecraft/client/entity/EntityPlayerSP;
@@ -1521,7 +1535,7 @@ public final class gg/essential/universal/wrappers/UPlayer {
 	public static final fun sendClientSideMessage (Lnet/minecraft/util/IChatComponent;)V
 	@1.17.1-forge,1.18.1-forge,1.19.2-forge,1.19.3-forge,1.19.4-forge,1.20.1-forge,1.20.2-forge,1.20.4-forge,1.20.4-neoforge,1.20.6-forge,1.20.6-neoforge,1.21-forge,1.21-neoforge,1.21.3-forge,1.21.3-neoforge,1.21.4-forge,1.21.4-neoforge,1.21.5-forge,1.21.5-neoforge
 	public static final fun sendClientSideMessage (Lnet/minecraft/network/chat/Component;)V
-	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric
+	@1.16.2-fabric,1.17.1-fabric,1.18.1-fabric,1.19-fabric,1.19.1-fabric,1.19.2-fabric,1.19.3-fabric,1.19.4-fabric,1.20-fabric,1.20.1-fabric,1.20.2-fabric,1.20.4-fabric,1.20.6-fabric,1.21-fabric,1.21.3-fabric,1.21.4-fabric,1.21.5-fabric,1.21.6-fabric
 	public static final fun sendClientSideMessage (Lnet/minecraft/text/Text;)V
 	@1.12.2-forge,1.16.2-forge
 	public static final fun sendClientSideMessage (Lnet/minecraft/util/text/ITextComponent;)V

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -12,6 +12,7 @@ version = versionFromBuildIdAndBranch()
 preprocess {
     strictExtraMappings.set(true)
 
+    val fabric12106 = createNode("1.21.6-fabric", 12106, "srg")
     val neoForge12105 = createNode("1.21.5-neoforge", 12105, "srg")
     val forge12105 = createNode("1.21.5-forge", 12105, "srg")
     val fabric12105 = createNode("1.21.5-fabric", 12105, "srg")
@@ -52,6 +53,7 @@ preprocess {
     val forge11202 = createNode("1.12.2-forge", 11202, "srg")
     val forge10809 = createNode("1.8.9-forge", 10809, "srg")
 
+    fabric12106.link(fabric12105)
     neoForge12105.link(fabric12105)
     forge12105.link(fabric12105)
     fabric12105.link(fabric12104, file("versions/1.21.5-1.21.4.txt"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -60,6 +60,7 @@ listOf(
     "1.21.5-fabric",
     "1.21.5-forge",
     "1.21.5-neoforge",
+    "1.21.6-fabric",
 ).forEach { version ->
     include(":$version")
     project(":$version").apply {

--- a/src/main/kotlin/gg/essential/universal/UMatrixStack.kt
+++ b/src/main/kotlin/gg/essential/universal/UMatrixStack.kt
@@ -55,6 +55,24 @@ class UMatrixStack private constructor(
     //$$ fun toMC() = peek().toMCStack()
     //#endif
 
+    //#if MC>=12106
+    //$$ constructor(mc: org.joml.Matrix3x2f) : this() {
+    //$$     peek().model.apply {
+    //$$         m00(mc.m00)
+    //$$         m01(mc.m01)
+    //$$         m10(mc.m10)
+    //$$         m11(mc.m11)
+    //$$         m30(mc.m20)
+    //$$         m31(mc.m21)
+    //$$     }
+    //$$ }
+    //$$ fun to3x2Joml(dst: org.joml.Matrix3x2f = org.joml.Matrix3x2f()): org.joml.Matrix3x2f {
+    //$$     val uc = peek().model
+    //$$     dst.set(uc.m00(), uc.m01(), uc.m10(), uc.m11(), uc.m30(), uc.m31())
+    //$$     return dst
+    //$$ }
+    //#endif
+
     fun translate(x: Double, y: Double, z: Double) = translate(x.toFloat(), y.toFloat(), z.toFloat())
 
     fun translate(x: Float, y: Float, z: Float) {

--- a/src/main/kotlin/gg/essential/universal/UResolution.kt
+++ b/src/main/kotlin/gg/essential/universal/UResolution.kt
@@ -112,6 +112,9 @@ object UResolution {
             //$$ return UMinecraft.guiScale.toDouble()
             //#elseif MC>=11502
             //$$ return UMinecraft.getMinecraft().mainWindow.guiScaleFactor
+                //#if MC>=12106
+                //$$ .toDouble()
+                //#endif
             //#else
             return get().scaleFactor.toDouble()
             //#endif

--- a/src/main/kotlin/gg/essential/universal/render/ScissorState.kt
+++ b/src/main/kotlin/gg/essential/universal/render/ScissorState.kt
@@ -3,13 +3,15 @@ package gg.essential.universal.render
 import org.lwjgl.opengl.GL11
 import java.nio.ByteBuffer
 
-//#if MC>=12105 && !STANDALONE
+//#if MC==12105
 //$$ import com.mojang.blaze3d.systems.RenderSystem
 //#endif
 
 internal data class ScissorState(val enabled: Boolean, val x: Int, val y: Int, val width: Int, val height: Int) {
     fun activate() {
-        //#if MC>=12105 && !STANDALONE
+        //#if MC>=12106 && !STANDALONE
+        //$$ active = this
+        //#elseif MC==12105
         //$$ if (enabled) {
         //$$     RenderSystem.SCISSOR_STATE.enable(x, y, width, height)
         //$$ } else {
@@ -28,11 +30,18 @@ internal data class ScissorState(val enabled: Boolean, val x: Int, val y: Int, v
     companion object {
         val DISABLED = ScissorState(false, 0, 0, 0, 0)
 
+        //#if MC>=12106
+        //$$ // MC no longer has a global scissor state, so we'll have our own until we've migrated away from it too
+        //$$ private var active: ScissorState = DISABLED
+        //#endif
+
         // Note: LWJGL2 requires a buffer of 16 elements, even if the property we query only has 4
         private val tmpIntBuffer = ByteBuffer.allocateDirect(16 * Int.SIZE_BYTES).asIntBuffer()
 
         fun active(): ScissorState {
-            //#if MC>=12105 && !STANDALONE
+            //#if MC>=12106 && !STANDALONE
+            //$$ return active
+            //#elseif MC==12105
             //$$ return with(RenderSystem.SCISSOR_STATE) { ScissorState(isEnabled, x, y, width, height) }
             //#else
             val bounds = tmpIntBuffer

--- a/versions/1.21.6-fabric/gradle.properties
+++ b/versions/1.21.6-fabric/gradle.properties
@@ -1,2 +1,2 @@
-essential.defaults.loom.minecraft=com.mojang:minecraft:1.21.6-pre3
-essential.defaults.loom.mappings=net.fabricmc:yarn:1.21.6-pre3+build.1
+essential.defaults.loom.minecraft=com.mojang:minecraft:1.21.6-rc1
+essential.defaults.loom.mappings=net.fabricmc:yarn:1.21.6-rc1+build.1

--- a/versions/1.21.6-fabric/gradle.properties
+++ b/versions/1.21.6-fabric/gradle.properties
@@ -1,0 +1,2 @@
+essential.defaults.loom.minecraft=com.mojang:minecraft:1.21.6-pre3
+essential.defaults.loom.mappings=net.fabricmc:yarn:1.21.6-pre3+build.1

--- a/versions/1.21.6-fabric/src/main/kotlin/gg/essential/universal/AdvancedDrawContext.kt
+++ b/versions/1.21.6-fabric/src/main/kotlin/gg/essential/universal/AdvancedDrawContext.kt
@@ -1,0 +1,85 @@
+package gg.essential.universal
+
+import com.mojang.blaze3d.systems.ProjectionType
+import com.mojang.blaze3d.systems.RenderSystem
+import gg.essential.universal.utils.TemporaryTextureAllocator
+import net.minecraft.client.MinecraftClient
+import net.minecraft.client.gl.RenderPipelines
+import net.minecraft.client.gui.DrawContext
+import net.minecraft.client.render.ProjectionMatrix2
+import net.minecraft.client.texture.AbstractTexture
+import net.minecraft.util.Identifier
+
+internal object AdvancedDrawContext {
+    private var allocatedProjectionMatrix: ProjectionMatrix2? = null
+
+    private val textureAllocator = TemporaryTextureAllocator {
+        allocatedProjectionMatrix?.close()
+        allocatedProjectionMatrix = null
+    }
+
+    fun drawImmediate(context: DrawContext, block: (UMatrixStack) -> Unit) {
+        val scaleFactor = UResolution.scaleFactor.toFloat()
+        val width = UResolution.viewportWidth
+        val height = UResolution.viewportHeight
+
+        val texture = textureAllocator.allocate(width, height)
+
+        var projectionMatrix = allocatedProjectionMatrix
+        if (projectionMatrix == null) {
+            projectionMatrix = ProjectionMatrix2("pre-rendered screen", 1000f, 21000f, true)
+            allocatedProjectionMatrix = projectionMatrix
+        }
+        RenderSystem.setProjectionMatrix(
+            projectionMatrix.set(width.toFloat() / scaleFactor, height.toFloat() / scaleFactor),
+            ProjectionType.ORTHOGRAPHIC,
+        )
+
+        val orgOutputColorTextureOverride = RenderSystem.outputColorTextureOverride
+        val orgOutputDepthTextureOverride = RenderSystem.outputDepthTextureOverride
+        RenderSystem.outputColorTextureOverride = texture.textureView
+        RenderSystem.outputDepthTextureOverride = texture.depthTextureView
+
+        val matrixStack = UMatrixStack()
+        matrixStack.translate(0f, 0f, -10000f)
+        block(matrixStack)
+
+        RenderSystem.outputColorTextureOverride = orgOutputColorTextureOverride
+        RenderSystem.outputDepthTextureOverride = orgOutputDepthTextureOverride
+
+        draw(context, texture)
+    }
+
+    fun draw(context: DrawContext, texture: TemporaryTextureAllocator.TextureAllocation) {
+        val width = texture.width
+        val height = texture.height
+        val scaleFactor = UResolution.scaleFactor.toFloat()
+
+        val textureManager = MinecraftClient.getInstance().textureManager
+        val identifier = Identifier.of("universalcraft", "__tmp_texture__")
+        textureManager.registerTexture(identifier, object : AbstractTexture() {
+            init { glTextureView = texture.textureView }
+            override fun close() {} // we don't want the later `destroyTexture` to close our texture
+        })
+
+        context.matrices.pushMatrix()
+        context.matrices.scale(1/scaleFactor, 1/scaleFactor) // drawTexture only accepts `int`s
+        context.drawTexture(
+            RenderPipelines.GUI_TEXTURED_PREMULTIPLIED_ALPHA,
+            identifier,
+            // x, y
+            0, 0,
+            // u, v
+            0f, height.toFloat(),
+            // width, height
+            width, height,
+            // uWidth, vHeight
+            width, -height,
+            // textureWidth, textureHeight
+            width, height,
+        )
+        context.matrices.popMatrix()
+
+        textureManager.destroyTexture(identifier)
+    }
+}

--- a/versions/1.21.6-fabric/src/main/kotlin/gg/essential/universal/utils/TemporaryTextureAllocator.kt
+++ b/versions/1.21.6-fabric/src/main/kotlin/gg/essential/universal/utils/TemporaryTextureAllocator.kt
@@ -1,0 +1,109 @@
+package gg.essential.universal.utils
+
+import com.mojang.blaze3d.systems.RenderSystem
+import com.mojang.blaze3d.textures.FilterMode
+import com.mojang.blaze3d.textures.GpuTexture
+import com.mojang.blaze3d.textures.TextureFormat
+import net.minecraft.client.MinecraftClient
+
+/**
+ * Allocates temporary textures, which are valid for one frame, from a pool.
+ */
+internal class TemporaryTextureAllocator(
+    private val allCleanedUp: () -> Unit = {},
+) {
+    private var taskQueued = false
+
+    // When we allocate a texture, we need to hold on to it until the next frame so MC's gui renderer can use it
+    private val usedAllocations = mutableListOf<TextureAllocation>()
+    // We hold on to it for an additionally frame so we can re-use it instead of having to re-allocate one each frame
+    private val reusableAllocations = mutableListOf<TextureAllocation>()
+
+    fun allocate(width: Int, height: Int): TextureAllocation {
+        var texture = reusableAllocations.removeLastOrNull()
+
+        if (texture != null && (texture.width != width || texture.height != height)) {
+            texture.close()
+            texture = null
+        }
+
+        if (texture == null) {
+            texture = TextureAllocation(width, height)
+        }
+
+        val device = RenderSystem.getDevice()
+        device.createCommandEncoder().clearColorAndDepthTextures(texture.texture, 0, texture.depthTexture, 1.0)
+
+        usedAllocations.add(texture)
+        queueCleanup()
+
+        return texture
+    }
+
+    fun free(allocation: TextureAllocation) {
+        if (usedAllocations.remove(allocation)) {
+            reusableAllocations.add(allocation)
+        }
+    }
+
+    private fun queueCleanup() {
+        if (!taskQueued) {
+            taskQueued = true
+            MinecraftClient.getInstance().send(::cleanup)
+        }
+    }
+
+    private fun cleanup() {
+        taskQueued = false
+
+        reusableAllocations.forEach { it.close() }
+        reusableAllocations.clear()
+        reusableAllocations.addAll(usedAllocations)
+        usedAllocations.clear()
+
+        if (reusableAllocations.isEmpty()) {
+            allCleanedUp()
+        }
+
+        if (reusableAllocations.isNotEmpty()) {
+            // We don't care about the fencing here, we just need a way to submit a task for a future frame
+            RenderSystem.queueFencedTask { queueCleanup() }
+        }
+    }
+
+    class TextureAllocation(
+        val width: Int,
+        val height: Int,
+    ) : AutoCloseable {
+        private val gpuDevice = RenderSystem.getDevice()
+
+        var texture = gpuDevice.createTexture(
+            { "Pre-rendered texture" },
+            GpuTexture.USAGE_RENDER_ATTACHMENT or GpuTexture.USAGE_TEXTURE_BINDING,
+            TextureFormat.RGBA8,
+            width,
+            height,
+            1,
+            1
+        ).apply { setTextureFilter(FilterMode.NEAREST, false) }
+        var depthTexture = gpuDevice.createTexture(
+            { "Pre-rendered depth texture" },
+            GpuTexture.USAGE_RENDER_ATTACHMENT,
+            TextureFormat.DEPTH32,
+            width,
+            height,
+            1,
+            1
+        )
+
+        var textureView = gpuDevice.createTextureView(texture)
+        var depthTextureView = gpuDevice.createTextureView(depthTexture)
+
+        override fun close() {
+            depthTextureView.close()
+            textureView.close()
+            depthTexture.close()
+            texture.close()
+        }
+    }
+}


### PR DESCRIPTION
With 1.21.6 MC introduces a new gui renderer which now first collects all the quads/text/etc., sorts it into batches of similar type (while respecting ordering) and then draws those batches all at once (in the future even on a different thread).

Adapting UniversalCraft to this new paradigm isn't easy, since it's pretty much been ignoring the whole `DrawContext` concept so far. As such, for the time being, until we've designed a new universal gui rendering api, UScreen is now rendering exactly as it did before but to a temporary texture and then it submits that texture as a full-screen quad to MC's gui renderer.