### PR TITLE
UScreen: Fix broken projection matrix after background rendering

### DIFF
--- a/src/main/kotlin/gg/essential/universal/UScreen.kt
+++ b/src/main/kotlin/gg/essential/universal/UScreen.kt
@@ -422,19 +422,17 @@ abstract class UScreen(
         //$$ withDrawContext(matrixStack) { drawContext ->
             //#if MC>=12106
             //$$ drawContext.createNewRootLayer()
-            //#endif
-            //#if MC>=12106
             //$$ val orgProjectionMatrixBuffer = RenderSystem.getProjectionMatrixBuffer()
             //$$ val orgProjectionType = RenderSystem.getProjectionType()
-            //$$ super.renderBackground(drawContext, lastBackgroundMouseX, lastBackgroundMouseY, lastBackgroundDelta)
-            //$$ @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
-            //$$ RenderSystem.setProjectionMatrix(orgProjectionMatrixBuffer, orgProjectionType)
-            //#elseif MC>=12002
+            //#endif
+            //#if MC>=12002
             //$$ super.renderBackground(drawContext, lastBackgroundMouseX, lastBackgroundMouseY, lastBackgroundDelta)
             //#else
             //$$ super.renderBackground(drawContext)
             //#endif
             //#if MC>=12106
+            //$$ @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
+            //$$ RenderSystem.setProjectionMatrix(orgProjectionMatrixBuffer, orgProjectionType)
             //$$ drawContext.createNewRootLayer()
             //#endif
         //$$ }


### PR DESCRIPTION
The panorama background renderer sets (and doesn't restore) the global projection matrix to use perspective projection, so we need to save it before calling the `renderBackground` method and restore it afterwards. This isn't a problem for vanilla because it doesn't use the projection matrix during gui screen drawing (it sets up a new one in GuiRenderer once it actually commits the draw calls), but our `AdvancedDrawContext` does.

The is masked with Essential installed because it uses `AdvancedDrawContext` for its overlays which re-sets a proper projection matrix (at least right now because it doesn't yet optimize to check if there is actually anything to display, nor does it capture+restore the projection matrix, which it probably should).