### PR TITLE
UGraphics: Fix drawString with custom shadow color and bold font

### DIFF
--- a/src/main/java/gg/essential/universal/UGraphics.java
+++ b/src/main/java/gg/essential/universal/UGraphics.java
@@ -620,6 +620,7 @@ public class UGraphics {
         //#if MC>=12106
         //$$ GlyphDrawerImpl drawerImpl = new GlyphDrawerImpl(stack.peek().getModel());
         //$$ UMinecraft.getFontRenderer().prepare(shadowText, x + 1f, y + 1f, shadowColor, false, 0).draw(drawerImpl);
+        //$$ drawerImpl.matrix = drawerImpl.matrix.translate(0f, 0f, TextRenderer.FORWARD_SHIFT, new org.joml.Matrix4f());
         //$$ UMinecraft.getFontRenderer().prepare(text, x, y, color, false, 0).draw(drawerImpl);
         //$$ drawerImpl.flush();
         //#else
@@ -651,7 +652,7 @@ public class UGraphics {
     //#if MC>=12106 && !STANDALONE
     //$$ private static class GlyphDrawerImpl implements TextRenderer.GlyphDrawer {
     //$$     private static final int LIGHT = 0x00F0_00F0; // see GlyphGuiElementRenderState.setupVertices
-    //$$     private final org.joml.Matrix4f matrix;
+    //$$     private org.joml.Matrix4f matrix;
     //$$     private RenderPipeline pipeline;
     //$$     private GpuTextureView texture;
     //$$     private BufferBuilder bufferBuilder;


### PR DESCRIPTION
To render with a custom shadow color, which is not something Minecraft's builtin shadow rendering supports, we render the same text twice with the first time offset and colored to appear as the shadow. To render bold font, Minecraft draws each glyph twice with the second time offset by 1 horizontally to give the bold effect.

Prior to Minecraft 1.21.6, when no builtin shadow in involved (as is the case with our custom shadow rendering), both of these glyph rectangles had the exact same z value, and therefore all rectangles drawn for our shadow pass and our text pass all had the exact same z values. The default depth test function is LESS_EQUAL, so all rectangles were drawn based purely on the draw call order.
As of Minecraft 1.21.6 however, the vanilla text renderer now places the second rectangle of a bold glpyh every so slightly (0.001) closer to the camera (presumably to prevent some weird z-fighting when viewed at just the wrong angles). This means the second rectangle of our shadow pass will now appear in front of the first rectangle of our regular pass, giving incorrect results.

This commit fixes the issue by doing what vanilla does (and has done even prior to 1.21.6, we just didn't need it there) when you use its builtin shadow rendering: Offset the normal pass to be in front of the shadow pass. And notably more (0.003) than the second rectangle of a bold glyph, such that the normal pass is now always completely in front of the shadow pass.

Note: Requires https://github.com/EssentialGG/UniversalCraft/pull/109 to function correctly on 1.21.7 because the `FORWARD_SHIFT` constant (as well as the other offsets internally to `TextRenderer`) was changed in 1.21.7 to be an order of magnitude larger, but the Java compiler inlines constants, so we need to actually compile against 1.21.7 to use the correct value on 1.21.7.