### PR TITLE
ReleasedDynamicTexture: Fix default nearest min/mag filter not being applied on 1.21.5+

### DIFF
--- a/src/main/kotlin/gg/essential/universal/utils/ReleasedDynamicTexture.kt
+++ b/src/main/kotlin/gg/essential/universal/utils/ReleasedDynamicTexture.kt
@@ -127,6 +127,13 @@ class ReleasedDynamicTexture private constructor(
             //$$ val texture = device.createTexture(null as String?, TextureFormat.RGBA8, width, height, 1)
             //#endif
             //$$ texture.setTextureFilter(FilterMode.NEAREST, true)
+            //$$ UGraphics.configureTexture((texture as GlTexture).glId) {
+                //#if MC>=12106
+                //$$ texture.checkDirty(GL11.GL_TEXTURE_2D)
+                //#else
+                //$$ texture.checkDirty()
+                //#endif
+            //$$ }
             //$$ device.createCommandEncoder().writeToTexture(texture, textureData!!)
             //$$ textureData = null
             //$$ uploaded = true


### PR DESCRIPTION
The 1.21.5 `setTextureFilter` method doesn't actually apply the filter to the OpenGL object, it merely stores the desired values inside the `GpuTexture` object which are then applied lazily in `GlCommandEncoder.setupRenderPass`.
This however necessitates that the same `GpuTexture` object that was created here is also passed to the render pass, and since a lot of UniversalCraft-using code simply passes around raw OpenGL IDs, this isn't often the case (in fact, our URenderPass doesn't even support accepting MC's `GpuTexture` type).

A proper solution would be to introduce a universal `GpuTexture` type and to deprecate all the old raw OpenGL ID APIs. This however introduces a lot of new API surface, so I'd want to get it right, and I'm not yet confident enough in having a good picture of how this new API should look.

This commit fixes the issue by eagerly applying the filter during construction, matching the behavior of older MC versions.

Another alternate solution I had considered was to internally pass around the `GpuTexture` objects via a global weak Map which maps OpenGL IDs to ReleasedDynamicTexture objects. However, this would break existing users which re-configure the filter mode via raw OpenGL before rendering, since any such modification would then be lost when MC applies the filters configured on the `GpuTexture` object.

Linear: EM-3194