### PR TITLE
Build: Replace deprecated `-Xjvm-default` with stable `-jvm-default`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import gg.essential.gradle.util.*
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
@@ -11,7 +12,7 @@ plugins {
 group = "gg.essential"
 
 java.withSourcesJar()
-tasks.compileKotlin.setJvmDefault("all")
+kotlin.compilerOptions.jvmDefault.set(JvmDefaultMode.NO_COMPATIBILITY)
 loom.noServerRunConfigs()
 
 dependencies {

--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -1,5 +1,5 @@
 import com.replaymod.gradle.preprocess.PreprocessTask
-import gg.essential.gradle.util.setJvmDefault
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 
 plugins {
     kotlin("jvm")
@@ -15,7 +15,7 @@ base.archivesName = "universalcraft-standalone"
 kotlin.compilerOptions.moduleName = "universalcraft-standalone"
 publishing.publications.named<MavenPublication>("maven") { artifactId = "universalcraft-standalone" }
 java.withSourcesJar()
-tasks.compileKotlin.setJvmDefault("all")
+kotlin.compilerOptions.jvmDefault.set(JvmDefaultMode.NO_COMPATIBILITY)
 kotlin.jvmToolchain(8)
 
 dependencies {


### PR DESCRIPTION
https://kotlinlang.org/docs/whatsnew22.html#changes-to-default-method-generation-for-interface-functions