### PR TITLE
URenderPipeline: Add missing `Projection` uniform

### DIFF
--- a/src/main/kotlin/gg/essential/universal/render/URenderPipeline.kt
+++ b/src/main/kotlin/gg/essential/universal/render/URenderPipeline.kt
@@ -656,6 +656,7 @@ class URenderPipeline private constructor(
             //$$ val uniforms = mapOf(
                 //#if MC>=12106
                 //$$ "DynamicTransforms" to UniformType.UNIFORM_BUFFER,
+                //$$ "Projection" to UniformType.UNIFORM_BUFFER,
                 //#else
                 //$$ "ModelViewMat" to UniformType.MATRIX4X4,
                 //$$ "ProjMat" to UniformType.MATRIX4X4,


### PR DESCRIPTION
While the `DynamicTransforms` combines most of the pre-1.21.6 uniforms into a single block, the `ProjMat` uniform has actually become its own `Projection` uniform block.

It seems like Minecraft was using this info mostly for validation, but didn't complain when the shader actually used uniforms that weren't declared, hence why this wasn't noticed. But that is no longer the case with the Vulkan backend.