### PR TITLE
Build: Increase `MC` version used for `standalone` project

### DIFF
--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -84,7 +84,7 @@ fun setupPreprocessor() {
             ".kt" to PreprocessTask.DEFAULT_KEYWORDS,
         )
         vars = mapOf(
-            "MC" to 99999,
+            "MC" to 99_99_99,
             "FABRIC" to 1,
             "FORGE" to 0,
             "NEOFORGE" to 0,


### PR DESCRIPTION
Now that 26.1 (26_01_00) is a thing, 99999 (9_99_99) isn't enough to always be on top.

Haven't actually ran into a case where it makes a difference with the 26.1 port, but am runing into plenty such cases with 26.2 and related PRs.