### PR TITLE
ShaderTransformer: Fix integer texture attributes

### DIFF
--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -79,7 +79,7 @@ preprocess {
     fabric12103.link(fabric12100)
     neoForge12100.link(fabric12100)
     forge12100.link(fabric12100)
-    fabric12100.link(fabric12006)
+    fabric12100.link(fabric12006, file("versions/1.21-1.20.6.txt"))
     neoForge12006.link(fabric12006)
     forge12006.link(fabric12006)
     fabric12006.link(fabric12004)

--- a/src/main/kotlin/gg/essential/universal/shader/ShaderTransformer.kt
+++ b/src/main/kotlin/gg/essential/universal/shader/ShaderTransformer.kt
@@ -4,6 +4,11 @@ package gg.essential.universal.shader
 //$$ import gg.essential.universal.standalone.render.VertexFormat
 //#else
 import net.minecraft.client.renderer.vertex.VertexFormat
+import net.minecraft.client.renderer.vertex.VertexFormatElement
+
+//#if MC >= 26.2
+//$$ import com.mojang.blaze3d.GpuFormat
+//#endif
 //#endif
 
 internal class ShaderTransformer(private val vertexFormat: VertexFormat?, private val targetVersion: Int) {
@@ -55,12 +60,19 @@ internal class ShaderTransformer(private val vertexFormat: VertexFormat?, privat
             }
         }
         if (vert) {
+            //#if STANDALONE
+            //$$ fun uvVecType(index: Int) = "vec2"
+            //#else
+            fun uvVecType(index: Int) =
+                if (vertexFormat?.uvIsFloat(index) ?: true) "vec2" else "ivec2"
+            //#endif
+
             val newAttributes = mutableListOf<Pair<String, String>>()
             replaceAttribute(newAttributes, "gl_Vertex", "vec3", "uc_Position", replacement = "vec4(uc_Position, 1.0)")
             replaceAttribute(newAttributes, "gl_Color", "vec4")
-            replaceAttribute(newAttributes, "gl_MultiTexCoord0.st", "vec2", "uc_UV0")
-            replaceAttribute(newAttributes, "gl_MultiTexCoord1.st", "vec2", "uc_UV1")
-            replaceAttribute(newAttributes, "gl_MultiTexCoord2.st", "vec2", "uc_UV2")
+            replaceAttribute(newAttributes, "gl_MultiTexCoord0.st", uvVecType(0), "uc_UV0")
+            replaceAttribute(newAttributes, "gl_MultiTexCoord1.st", uvVecType(1), "uc_UV1")
+            replaceAttribute(newAttributes, "gl_MultiTexCoord2.st", uvVecType(2), "uc_UV2")
 
             if (vertexFormat != null) {
                 //#if MC>=11700 && !STANDALONE
@@ -146,6 +158,29 @@ internal class ShaderTransformer(private val vertexFormat: VertexFormat?, privat
         return transformed.joinToString("\n")
     }
 }
+
+//#if !STANDALONE
+private fun VertexFormat.uvIsFloat(i: Int): Boolean =
+    //#if MC >= 26.2
+    //$$ this.getElement("UV$i")
+    //#elseif MC >= 26.1
+    //$$ this.elements.getOrNull(this.elementAttributeNames.indexOf("UV$i"))
+    //#else
+    this.elements
+        .asSequence()
+        .filter { it.usage == VertexFormatElement.EnumUsage.UV }
+        .elementAtOrNull(i)
+    //#endif
+        ?.isFloat()
+        ?: true
+
+private fun VertexFormatElement.isFloat() =
+    //#if MC >= 26.2
+    //$$ this.format == GpuFormat.RG16_FLOAT || this.format == GpuFormat.RG32_FLOAT
+    //#else
+    this.type == VertexFormatElement.EnumType.FLOAT
+    //#endif
+//#endif
 
 internal enum class UniformType(val typeName: String, val glslName: String, val default: IntArray) {
     Int1("int", "int", intArrayOf(0)),

--- a/versions/1.21-1.20.6.txt
+++ b/versions/1.21-1.20.6.txt
@@ -1,0 +1,2 @@
+net.minecraft.client.render.VertexFormatElement type() getComponentType()
+net.minecraft.client.render.VertexFormatElement usage() getType()

--- a/versions/1.21.5-1.21.4.txt
+++ b/versions/1.21.5-1.21.4.txt
@@ -1,3 +1,5 @@
 com.mojang.blaze3d.vertex.VertexFormat net.minecraft.client.render.VertexFormat
 com.mojang.blaze3d.vertex.VertexFormat getElementAttributeNames() getAttributeNames()
+com.mojang.blaze3d.vertex.VertexFormatElement net.minecraft.client.render.VertexFormatElement
+com.mojang.blaze3d.vertex.VertexFormatElement$Type net.minecraft.client.render.VertexFormatElement$ComponentType
 com.mojang.blaze3d.opengl.GlStateManager com.mojang.blaze3d.platform.GlStateManager


### PR DESCRIPTION
Minecraft uses integer formats (namely 16-bit signed integers) for its secondary (light and overlay) textures in all its `VertexFormat`s.

Previously the ShaderTransformer, used to convert legacy OpenGL shaders to more modern OpenGL, used to use the GLSL type `vec2` for all texture attributes. This resulted in broken values being delivered to the shader on modern versions (presumably because they're trying to interpret the bytes representing integer values as floating point values).

This commit fixes the issue by using `ivec2` where the provided VertexFormat contains an integer type for the attribute.